### PR TITLE
Major refactor of errors

### DIFF
--- a/cliquet/__init__.py
+++ b/cliquet/__init__.py
@@ -128,7 +128,7 @@ def end_of_life_tween_factory(handler, registry):
     """Pyramid tween to handle service end of life."""
 
     deprecated_response = errors.http_error(
-        HTTPGone,
+        HTTPGone(),
         errno=errors.ERRORS.SERVICE_DEPRECATED,
         message="The service you are trying to connect no longer exists "
                 "at this location.")

--- a/cliquet/authentication.py
+++ b/cliquet/authentication.py
@@ -4,11 +4,10 @@ import hmac
 from fxa.oauth import Client as OAuthClient
 from fxa import errors as fxa_errors
 from pyramid import authentication as base_auth
+from pyramid import httpexceptions
 from pyramid.interfaces import IAuthenticationPolicy, IAuthorizationPolicy
 from pyramid.security import Authenticated
 from zope.interface import implementer
-
-from cliquet.errors import HTTPServiceUnavailable
 
 
 def check_credentials(username, password, request):
@@ -77,7 +76,7 @@ class Oauth2AuthenticationPolicy(base_auth.CallbackAuthenticationPolicy):
                                profile['user'].encode('utf-8'),
                                hashlib.sha256).hexdigest()
         except fxa_errors.OutOfProtocolError:
-            raise HTTPServiceUnavailable()
+            raise httpexceptions.HTTPServiceUnavailable()
         except (fxa_errors.InProtocolError, fxa_errors.TrustError):
             return None
         return 'fxa_%s' % user_id

--- a/cliquet/errors.py
+++ b/cliquet/errors.py
@@ -23,13 +23,14 @@ ERRORS = Enum(
     BACKEND=201,
     SERVICE_DEPRECATED=202
 )
+"""Predefined errors as specified by the protocol."""
 
 
-def http_error(http_exception_klass, errno=None,
+def http_error(httpexception, errno=None,
                code=None, error=None, message=None, info=None):
     """Return a JSON formated response matching the error protocol.
 
-    :param http_exception_klass: See :mod:`pyramid.httpexceptions`
+    :param httpexception: Instance of :mod:`pyramid.httpexceptions`
     :param errno: stable application-level error number (e.g. 109)
     :param code: matches the HTTP status code (e.g 400)
     :param error: string description of error type (e.g. "Bad request")
@@ -39,9 +40,9 @@ def http_error(http_exception_klass, errno=None,
     :rtype: pyramid.httpexceptions.HTTPException
     """
     body = {
-        "code": code or http_exception_klass.code,
+        "code": code or httpexception.code,
         "errno": errno or ERRORS.UNDEFINED,
-        "error": error or http_exception_klass.title
+        "error": error or httpexception.title
     }
 
     if message is not None:
@@ -50,8 +51,9 @@ def http_error(http_exception_klass, errno=None,
     if info is not None:
         body['info'] = info
 
-    response = http_exception_klass(body=json.dumps(body).encode("utf-8"),
-                                    content_type='application/json')
+    response = httpexception
+    response.body = json.dumps(body).encode("utf-8")
+    response.content_type = 'application/json'
     return response
 
 
@@ -85,7 +87,7 @@ def json_error_handler(errors):
     else:
         message = '%(location)s: %(description)s' % error
 
-    response = http_error(httpexceptions.HTTPBadRequest,
+    response = http_error(httpexceptions.HTTPBadRequest(),
                           errno=ERRORS.INVALID_PARAMETERS,
                           error='Invalid parameters',
                           message=message)

--- a/cliquet/errors.py
+++ b/cliquet/errors.py
@@ -94,11 +94,16 @@ def json_error_handler(errors):
     return response
 
 
-def raise_invalid(request, location='body', **kwargs):
+def raise_invalid(request, location='body', name=None, description=None,
+                  **kwargs):
     """Helper to raise a validation error.
+
+    :param location: location in request (e.g. ``'querystring'``)
+    :param name: field name
+    :param description: detailed description of validation error
 
     :raises: :class:`pyramid.httpexceptions.HTTPBadRequest`
     """
-    request.errors.add(location, **kwargs)
+    request.errors.add(location, name, description, **kwargs)
     response = json_error_handler(request.errors)
     raise response

--- a/cliquet/resource.py
+++ b/cliquet/resource.py
@@ -91,7 +91,7 @@ class BaseResource(object):
             return self.db.get(record_id=record_id,
                                **self.db_kwargs)
         except storage_exceptions.RecordNotFoundError:
-            response = http_error(HTTPNotFound,
+            response = http_error(HTTPNotFound(),
                                   errno=ERRORS.INVALID_RESOURCE_ID)
             raise response
 
@@ -178,7 +178,7 @@ class BaseResource(object):
 
             if current_timestamp > unmodified_since:
                 error_msg = 'Resource was modified meanwhile'
-                response = http_error(HTTPPreconditionFailed,
+                response = http_error(HTTPPreconditionFailed(),
                                       errno=ERRORS.MODIFIED_MEANWHILE,
                                       message=error_msg)
                 self.add_timestamp_header(response)
@@ -194,7 +194,7 @@ class BaseResource(object):
         field = exception.field
         existing = exception.record[self.id_field]
         message = 'Conflict of field {0} on record {1}'.format(field, existing)
-        response = http_error(HTTPConflict,
+        response = http_error(HTTPConflict(),
                               errno=ERRORS.CONSTRAINT_VIOLATED,
                               message=message)
         response.existing = exception.record

--- a/cliquet/resource.py
+++ b/cliquet/resource.py
@@ -10,7 +10,8 @@ import six
 from six.moves.urllib.parse import urlencode
 
 from cliquet.storage import exceptions as storage_exceptions, Filter, Sort
-from cliquet import errors
+from cliquet.errors import (http_error, raise_invalid, ERRORS,
+                            json_error_handler)
 from cliquet.schema import ResourceSchema
 from cliquet.utils import (
     COMPARISON, classname, native_value, decode_token, encode_token
@@ -28,7 +29,7 @@ def crud(**kwargs):
         params = dict(collection_path='/{0}s'.format(resource_name),
                       path='/{0}s/{{id}}'.format(resource_name),
                       description='Collection of {0}'.format(resource_name),
-                      error_handler=errors.json_error,
+                      error_handler=json_error_handler,
                       cors_origins=('*',),
                       depth=2)
         params.update(**kwargs)
@@ -78,15 +79,6 @@ class BaseResource(object):
 
         return CorniceSchema.from_colander(colander_schema)
 
-    def raise_invalid(self, location='body', **kwargs):
-        """Helper to raise a validation error.
-
-        :raises: :class:`pyramid.httpexceptions.HTTPBadRequest`
-        """
-        self.request.errors.add(location, **kwargs)
-        response = errors.json_error(self.request.errors)
-        raise response
-
     def fetch_record(self):
         """Fetch current view related record, and raise 404 if missing.
 
@@ -99,12 +91,8 @@ class BaseResource(object):
             return self.db.get(record_id=record_id,
                                **self.db_kwargs)
         except storage_exceptions.RecordNotFoundError:
-            response = HTTPNotFound(
-                body=errors.format_error(
-                    code=HTTPNotFound.code,
-                    errno=errors.ERRORS.INVALID_RESOURCE_ID,
-                    error=HTTPNotFound.title),
-                content_type='application/json')
+            response = http_error(HTTPNotFound,
+                                  errno=ERRORS.INVALID_RESOURCE_ID)
             raise response
 
     def process_record(self, new, old=None):
@@ -123,8 +111,11 @@ class BaseResource(object):
         for field, value in changes.items():
             has_changed = record.get(field, value) != value
             if self.mapping.is_readonly(field) and has_changed:
-                error = 'Cannot modify {0}'.format(field)
-                self.raise_invalid(name=field, description=error)
+                error_details = {
+                    'name': field,
+                    'description': 'Cannot modify {0}'.format(field)
+                }
+                raise_invalid(self.request, **error_details)
 
         updated = record.copy()
         updated.update(**changes)
@@ -138,8 +129,7 @@ class BaseResource(object):
         except colander.Invalid as e:
             # Transform the errors we got from colander into cornice errors
             for field, error in e.asdict().items():
-                self.request.errors.add('body', name=field, description=error)
-            raise errors.json_error(self.request.errors)
+                raise_invalid(self.request, name=field, description=error)
 
     def add_timestamp_header(self, response):
         """Add current timestamp in response headers, when request comes in.
@@ -188,13 +178,9 @@ class BaseResource(object):
 
             if current_timestamp > unmodified_since:
                 error_msg = 'Resource was modified meanwhile'
-                response = HTTPPreconditionFailed(
-                    body=errors.format_error(
-                        code=HTTPPreconditionFailed.code,
-                        errno=errors.ERRORS.MODIFIED_MEANWHILE,
-                        error=HTTPPreconditionFailed.title,
-                        message=error_msg),
-                    content_type='application/json')
+                response = http_error(HTTPPreconditionFailed,
+                                      errno=ERRORS.MODIFIED_MEANWHILE,
+                                      message=error_msg)
                 self.add_timestamp_header(response)
                 raise response
 
@@ -208,13 +194,9 @@ class BaseResource(object):
         field = exception.field
         existing = exception.record[self.id_field]
         message = 'Conflict of field {0} on record {1}'.format(field, existing)
-        response = HTTPConflict(
-            body=errors.format_error(
-                code=HTTPConflict.code,
-                errno=errors.ERRORS.CONSTRAINT_VIOLATED,
-                error=HTTPConflict.title,
-                message=message),
-            content_type='application/json')
+        response = http_error(HTTPConflict,
+                              errno=ERRORS.CONSTRAINT_VIOLATED,
+                              message=message)
         response.existing = exception.record
         raise response
 
@@ -241,7 +223,7 @@ class BaseResource(object):
                         'location': 'querystring',
                         'description': 'Invalid value for _since'
                     }
-                    self.raise_invalid(**error_details)
+                    raise_invalid(self.request, **error_details)
 
                 if param == '_since':
                     operator = COMPARISON.GT
@@ -261,11 +243,10 @@ class BaseResource(object):
 
             if field not in self.known_fields:
                 error_details = {
-                    'name': None,
                     'location': 'querystring',
                     'description': "Unknown filter field '{0}'".format(param)
                 }
-                self.raise_invalid(**error_details)
+                raise_invalid(self.request, **error_details)
 
             filters.append(Filter(field, value, operator))
 
@@ -284,11 +265,10 @@ class BaseResource(object):
 
                 if field not in self.known_fields:
                     error_details = {
-                        'name': None,
                         'location': 'querystring',
                         'description': "Unknown sort field '{0}'".format(field)
                     }
-                    self.raise_invalid(**error_details)
+                    raise_invalid(self.request, **error_details)
 
                 direction = -1 if order == '-' else 1
                 sorting.append(Sort(field, direction))
@@ -338,11 +318,10 @@ class BaseResource(object):
                 limit = int(limit)
             except ValueError:
                 error_details = {
-                    'name': None,
                     'location': 'querystring',
                     'description': "_limit should be an integer"
                 }
-                self.raise_invalid(**error_details)
+                raise_invalid(self.request, **error_details)
 
         token = queryparams.get('_token', None)
         filters = []
@@ -351,11 +330,10 @@ class BaseResource(object):
                 last_record = decode_token(token)
             except (ValueError, TypeError):
                 error_details = {
-                    'name': None,
                     'location': 'querystring',
                     'description': "_token should be valid base64 JSON encoded"
                 }
-                self.raise_invalid(**error_details)
+                raise_invalid(self.request, **error_details)
 
             filters = self._build_pagination_rules(sorting, last_record)
         return filters, limit
@@ -511,8 +489,11 @@ class BaseResource(object):
 
         new_id = new_record.setdefault(self.id_field, record_id)
         if new_id != record_id:
-            error_msg = 'Record id does not match existing record'
-            self.raise_invalid(name=self.id_field, description=error_msg)
+            error_details = {
+                'name': self.id_field,
+                'description': 'Record id does not match existing record'
+            }
+            raise_invalid(self.request, **error_details)
 
         new_record = self.process_record(new_record, old=existing)
 

--- a/cliquet/storage/__init__.py
+++ b/cliquet/storage/__init__.py
@@ -18,7 +18,7 @@ class StorageBase(object):
     Configuration can be changed to choose which storage backend will
     persist the records.
 
-    :raises: cliquet.errors.HTTPServiceUnavailable
+    :raises: pyramid.httpexceptions.HTTPServiceUnavailable
     """
     def flush(self):
         """Remove every record from the storage.

--- a/cliquet/storage/postgresql/__init__.py
+++ b/cliquet/storage/postgresql/__init__.py
@@ -8,8 +8,9 @@ import psycopg2.extras
 import six
 from six.moves.urllib import parse as urlparse
 
+from pyramid import httpexceptions
+
 from cliquet import logger
-from cliquet import errors
 from cliquet.storage import StorageBase, exceptions, Filter
 from cliquet.utils import COMPARISON
 
@@ -71,7 +72,7 @@ class PostgreSQL(StorageBase):
             if conn and not conn.closed:
                 conn.rollback()
             if isinstance(e, psycopg2.OperationalError):
-                raise errors.HTTPServiceUnavailable()
+                raise httpexceptions.HTTPServiceUnavailable()
             raise
         finally:
             if cursor:

--- a/cliquet/tests/test_storage.py
+++ b/cliquet/tests/test_storage.py
@@ -9,7 +9,8 @@ from cliquet.storage import (
     redis as redisbackend, postgresql,
     Sort, StorageBase
 )
-from cliquet import utils, errors
+from cliquet import utils
+from pyramid import httpexceptions
 from pyramid.config import global_registries
 
 from .support import unittest, ThreadMixin
@@ -634,7 +635,7 @@ class PostgresqlStorageTest(StorageTest, unittest.TestCase):
 
         with mock.patch('cliquet.storage.postgresql.PostgreSQL._check_unicity',
                         side_effect=psycopg2.OperationalError):
-            self.assertRaises(errors.HTTPServiceUnavailable,
+            self.assertRaises(httpexceptions.HTTPServiceUnavailable,
                               self.storage.create,
                               self.resource, 'foo', {})
 

--- a/cliquet/views/batch.py
+++ b/cliquet/views/batch.py
@@ -100,7 +100,7 @@ def post_batch(request):
         except Exception as e:
             logger.exception(e)
             subresponse = errors.http_error(
-                httpexceptions.HTTPInternalServerError)
+                httpexceptions.HTTPInternalServerError())
 
         subresponse = build_response(subresponse, subrequest)
         responses.append(subresponse)

--- a/cliquet/views/batch.py
+++ b/cliquet/views/batch.py
@@ -70,7 +70,7 @@ class BatchPayloadSchema(colander.MappingSchema):
 
 batch = Service(name="batch", path='/batch',
                 description="Batch operations",
-                error_handler=errors.json_error)
+                error_handler=errors.json_error_handler)
 
 
 @batch.post(schema=BatchPayloadSchema, permission=NO_PERMISSION_REQUIRED)
@@ -99,7 +99,8 @@ def post_batch(request):
             subresponse = e
         except Exception as e:
             logger.exception(e)
-            subresponse = errors.HTTPInternalServerError()
+            subresponse = errors.http_error(
+                httpexceptions.HTTPInternalServerError)
 
         subresponse = build_response(subresponse, subrequest)
         responses.append(subresponse)

--- a/cliquet/views/errors.py
+++ b/cliquet/views/errors.py
@@ -1,14 +1,18 @@
 from functools import wraps
 
 from pyramid import httpexceptions
+from pyramid.config import global_registries
 from pyramid.security import forget, NO_PERMISSION_REQUIRED
 from pyramid.view import (
     forbidden_view_config, notfound_view_config, view_config
 )
 
 from cliquet import logger
-from cliquet.errors import format_error, ERRORS, HTTPInternalServerError
+from cliquet.errors import http_error, ERRORS
 from cliquet.utils import reapply_cors
+
+
+DEFAULT_RETRY_AFTER_SECONDS = '30'
 
 
 def cors(view):
@@ -32,32 +36,45 @@ def authorization_required(request):
     not allowed (``403 Forbidden``).
     """
     if not request.authenticated_userid:
-        response = httpexceptions.HTTPUnauthorized(
-            body=format_error(
-                401, ERRORS.MISSING_AUTH_TOKEN, "Unauthorized",
-                "Please authenticate yourself to use this endpoint."),
-            content_type='application/json')
+        error_msg = "Please authenticate yourself to use this endpoint."
+        response = http_error(httpexceptions.HTTPUnauthorized,
+                              errno=ERRORS.MISSING_AUTH_TOKEN,
+                              message=error_msg)
         response.headers.extend(forget(request))
         return response
 
-    response = httpexceptions.HTTPForbidden(
-        body=format_error(
-            403, ERRORS.FORBIDDEN, "Forbidden",
-            "This user cannot access this resource."),
-        content_type='application/json')
+    error_msg = "This user cannot access this resource."
+    response = http_error(httpexceptions.HTTPForbidden,
+                          errno=ERRORS.FORBIDDEN,
+                          message=error_msg)
     return response
 
 
 @notfound_view_config()
 @cors
 def page_not_found(request):
-    """Return a JSON 404 error page."""
-    response = httpexceptions.HTTPNotFound(
-        body=format_error(
-            404, ERRORS.MISSING_RESOURCE, "Not Found",
-            "The resource your are looking for could not be found."),
-        content_type='application/json')
+    """Return a JSON 404 error response."""
+    error_msg = "The resource your are looking for could not be found."
+    response = http_error(httpexceptions.HTTPNotFound,
+                          errno=ERRORS.MISSING_RESOURCE,
+                          message=error_msg)
     return response
+
+
+@view_config(context=httpexceptions.HTTPServiceUnavailable,
+             permission=NO_PERMISSION_REQUIRED)
+def service_unavailable(context, request):
+
+    error_msg = "Service unavailable due to high load, please retry later."
+    response = http_error(httpexceptions.HTTPServiceUnavailable,
+                          errno=ERRORS.BACKEND,
+                          message=error_msg)
+
+    settings = global_registries.last.settings
+    retry_after = settings.get('cliquet.retry_after',
+                               DEFAULT_RETRY_AFTER_SECONDS)
+    response.headers["Retry-After"] = retry_after.encode("utf-8")
+    return reapply_cors(request, response)
 
 
 @view_config(context=Exception, permission=NO_PERMISSION_REQUIRED)
@@ -68,6 +85,10 @@ def error(context, request):
 
     logger.exception(context)
 
-    response = HTTPInternalServerError()
+    error_msg = "A programmatic error occured, developers have been informed."
+    info = "https://github.com/mozilla-services/cliquet/issues/"
+    response = http_error(httpexceptions.HTTPInternalServerError,
+                          message=error_msg,
+                          info=info)
 
     return reapply_cors(request, response)

--- a/cliquet/views/errors.py
+++ b/cliquet/views/errors.py
@@ -37,14 +37,14 @@ def authorization_required(request):
     """
     if not request.authenticated_userid:
         error_msg = "Please authenticate yourself to use this endpoint."
-        response = http_error(httpexceptions.HTTPUnauthorized,
+        response = http_error(httpexceptions.HTTPUnauthorized(),
                               errno=ERRORS.MISSING_AUTH_TOKEN,
                               message=error_msg)
         response.headers.extend(forget(request))
         return response
 
     error_msg = "This user cannot access this resource."
-    response = http_error(httpexceptions.HTTPForbidden,
+    response = http_error(httpexceptions.HTTPForbidden(),
                           errno=ERRORS.FORBIDDEN,
                           message=error_msg)
     return response
@@ -55,7 +55,7 @@ def authorization_required(request):
 def page_not_found(request):
     """Return a JSON 404 error response."""
     error_msg = "The resource your are looking for could not be found."
-    response = http_error(httpexceptions.HTTPNotFound,
+    response = http_error(httpexceptions.HTTPNotFound(),
                           errno=ERRORS.MISSING_RESOURCE,
                           message=error_msg)
     return response
@@ -66,7 +66,7 @@ def page_not_found(request):
 def service_unavailable(context, request):
 
     error_msg = "Service unavailable due to high load, please retry later."
-    response = http_error(httpexceptions.HTTPServiceUnavailable,
+    response = http_error(httpexceptions.HTTPServiceUnavailable(),
                           errno=ERRORS.BACKEND,
                           message=error_msg)
 
@@ -87,7 +87,7 @@ def error(context, request):
 
     error_msg = "A programmatic error occured, developers have been informed."
     info = "https://github.com/mozilla-services/cliquet/issues/"
-    response = http_error(httpexceptions.HTTPInternalServerError,
+    response = http_error(httpexceptions.HTTPInternalServerError(),
                           message=error_msg,
                           info=info)
 

--- a/docs/errors.rst
+++ b/docs/errors.rst
@@ -1,0 +1,7 @@
+Errors
+######
+
+.. _errors:
+
+.. automodule:: cliquet.errors
+    :members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,6 +13,7 @@ Table of content
    configuration
    resource
    storage
+   errors
    contributing
    glossary
    api/index


### PR DESCRIPTION
* Use a common error response factory everywhere
* Move raise_invalid to errors module
* Do not require Cliquet users to use our subclasses of Pyramid errors
* cliquet.errors can now go public