### PR TITLE
Update deleted_field support for postgres.

### DIFF
--- a/cliquet/storage/postgresql/__init__.py
+++ b/cliquet/storage/postgresql/__init__.py
@@ -290,7 +290,8 @@ class PostgreSQL(StorageBase):
 
         records = []
         for result in results:
-            record = dict([resource.deleted_field])
+            record = {}
+            record['deleted'] = True
             record[resource.id_field] = result['id']
             record[resource.modified_field] = result['last_modified']
             records.append(record)

--- a/cliquet/tests/test_storage.py
+++ b/cliquet/tests/test_storage.py
@@ -406,6 +406,13 @@ class DeletedRecordsTest(object):
         self.assertEqual(len(records), 1)
         self.assertEqual(count, 0)
 
+    def test_delete_all_deletes_records(self):
+        self.storage.create(self.resource, self.user_id, {'foo': 'bar'})
+        self.storage.create(self.resource, self.user_id, {'bar': 'baz'})
+        self.storage.delete_all(self.resource, self.user_id)
+        _, count = self.storage.get_all(self.resource, self.user_id)
+        self.assertEqual(count, 0)
+
     #
     # Sorting
     #


### PR DESCRIPTION
Without this, cliquet doesn't actually delete anything from the database.

r? @leplatrem @Natim ?