### PR TITLE
Handle backend errors for 503 (fixes #21)

### DIFF
--- a/cliquet/session/postgresql.py
+++ b/cliquet/session/postgresql.py
@@ -49,7 +49,7 @@ class PostgreSQL(PostgreSQLClient, SessionStorageBase):
         try:
             self.set('heartbeat', True)
             return True
-        except psycopg2.Error:
+        except:
             return False
 
     def ttl(self, key):

--- a/cliquet/session/postgresql.py
+++ b/cliquet/session/postgresql.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-import psycopg2
+
 from six.moves.urllib import parse as urlparse
 
 from cliquet import logger

--- a/cliquet/session/redis.py
+++ b/cliquet/session/redis.py
@@ -8,9 +8,9 @@ from cliquet.session import SessionStorageBase
 from cliquet.storage.redis import wrap_redis_error
 
 
-class RedisSessionStorage(SessionStorageBase):
+class Redis(SessionStorageBase):
     def __init__(self, *args, **kwargs):
-        super(RedisSessionStorage, self).__init__(*args, **kwargs)
+        super(Redis, self).__init__(*args, **kwargs)
         self._client = redis.StrictRedis(
             connection_pool=redis.BlockingConnectionPool(),
             **kwargs
@@ -58,7 +58,7 @@ def load_from_config(config):
     uri = settings.get('cliquet.session_url', '')
     uri = urlparse.urlparse(uri)
 
-    return RedisSessionStorage(host=uri.hostname or 'localhost',
-                               port=uri.port or 6739,
-                               password=uri.password or None,
-                               db=int(uri.path[1:]) if uri.path else 0)
+    return Redis(host=uri.hostname or 'localhost',
+                 port=uri.port or 6739,
+                 password=uri.password or None,
+                 db=int(uri.path[1:]) if uri.path else 0)

--- a/cliquet/session/redis.py
+++ b/cliquet/session/redis.py
@@ -5,6 +5,7 @@ import redis
 from six.moves.urllib import parse as urlparse
 
 from cliquet.session import SessionStorageBase
+from cliquet.storage.redis import wrap_redis_error
 
 
 class RedisSessionStorage(SessionStorageBase):
@@ -15,6 +16,7 @@ class RedisSessionStorage(SessionStorageBase):
             **kwargs
         )
 
+    @wrap_redis_error
     def flush(self):
         self._client.flushdb()
 
@@ -25,23 +27,28 @@ class RedisSessionStorage(SessionStorageBase):
         except redis.RedisError:
             return False
 
+    @wrap_redis_error
     def ttl(self, key):
         return self._client.ttl(key)
 
+    @wrap_redis_error
     def expire(self, key, value):
         self._client.pexpire(key, int(value * 1000))
 
+    @wrap_redis_error
     def set(self, key, value, ttl=None):
         if ttl:
             self._client.psetex(key, int(ttl * 1000), value)
         else:
             self._client.set(key, value)
 
+    @wrap_redis_error
     def get(self, key):
         value = self._client.get(key)
         if value:
             return value.decode('utf-8')
 
+    @wrap_redis_error
     def delete(self, key):
         self._client.delete(key)
 

--- a/cliquet/storage/exceptions.py
+++ b/cliquet/storage/exceptions.py
@@ -1,10 +1,21 @@
 """Exceptions raised by storage backend.
 """
 
+class BackendError(Exception):
+    """A generic exception raised by storage on error.
+
+    :param original: the wrapped exception raised by underlying library.
+    :type original: Exception
+    """
+    def __init__(self, original=None, *args, **kwargs):
+        self.original = original
+        super(BackendError, self).__init__(*args, **kwargs)
+
 
 class RecordNotFoundError(Exception):
-    """An exception raised by storage backend when a specific record
-    could not be found."""
+    """An exception raised when a specific record could not be found.
+
+    """
     pass
 
 
@@ -13,9 +24,12 @@ class IntegrityError(Exception):
 
 
 class UnicityError(IntegrityError):
-    """An exception raised by storage backend when the creation or the
-    modification of a record violates the unicity constraints defined by
-    the resource."""
+    """An exception raised on unicity constraint violation.
+
+    Raised by storage backend when the creation or the modification of a
+    record violates the unicity constraints defined by the resource.
+
+    """
     def __init__(self, field, record, *args, **kwargs):
         self.field = field
         self.record = record

--- a/cliquet/storage/exceptions.py
+++ b/cliquet/storage/exceptions.py
@@ -1,6 +1,7 @@
 """Exceptions raised by storage backend.
 """
 
+
 class BackendError(Exception):
     """A generic exception raised by storage on error.
 

--- a/cliquet/storage/postgresql/__init__.py
+++ b/cliquet/storage/postgresql/__init__.py
@@ -8,8 +8,6 @@ import psycopg2.extras
 import six
 from six.moves.urllib import parse as urlparse
 
-from pyramid import httpexceptions
-
 from cliquet import logger
 from cliquet.storage import StorageBase, exceptions, Filter
 from cliquet.utils import COMPARISON
@@ -50,9 +48,7 @@ class PostgreSQLClient(object):
             logger.exception(e)
             if conn and not conn.closed:
                 conn.rollback()
-            if isinstance(e, psycopg2.OperationalError):
-                raise httpexceptions.HTTPServiceUnavailable()
-            raise
+            raise exceptions.BackendError(original=e)
         finally:
             if cursor:
                 cursor.close()
@@ -147,7 +143,7 @@ class PostgreSQL(PostgreSQLClient, StorageBase):
             with self.connect() as cursor:
                 cursor.execute(query)
             return True
-        except psycopg2.Error:
+        except:
             return False
 
     def collection_timestamp(self, resource, user_id):

--- a/cliquet/tests/test_session.py
+++ b/cliquet/tests/test_session.py
@@ -4,6 +4,7 @@ import time
 import psycopg2
 import redis
 
+from cliquet.storage import exceptions
 from cliquet.session import SessionStorageBase, SessionCache
 from cliquet.session import (postgresql as postgresql_backend,
                              redis as redis_backend)
@@ -34,17 +35,39 @@ class BaseTestSessionStorage(object):
 
     settings = {}
 
-    def _get_config(self):
+    def __init__(self, *args, **kwargs):
+        super(BaseTestSessionStorage, self).__init__(*args, **kwargs)
+        self.session = self.backend.load_from_config(self._get_config())
+        self.client_error_patcher = None
+
+    def _get_config(self, settings=None):
         """Mock Pyramid config object.
         """
-        return mock.Mock(registry=mock.Mock(settings=self.settings))
+        if settings is None:
+            settings = self.settings
+        return mock.Mock(registry=mock.Mock(settings=settings))
 
     def tearDown(self):
+        mock.patch.stopall()
         super(BaseTestSessionStorage, self).tearDown()
         self.session.flush()
 
-    def setUp(self):
-        self.session = self.backend.load_from_config(self._get_config())
+    def test_backend_error_is_raised_anywhere(self):
+        self.client_error_patcher.start()
+        calls = [
+            (self.session.flush,),
+            (self.session.ttl, ''),
+            (self.session.expire, '', 0),
+            (self.session.get, ''),
+            (self.session.set, '', ''),
+            (self.session.delete, ''),
+        ]
+        for call in calls:
+            self.assertRaises(exceptions.BackendError, *call)
+
+    def test_ping_returns_an_error_if_unavailable(self):
+        self.client_error_patcher.start()
+        self.assertFalse(self.session.ping())
 
     def test_ping_returns_true_if_available(self):
         self.assertTrue(self.session.ping())
@@ -85,10 +108,12 @@ class BaseTestSessionStorage(object):
 class RedisSessionStorageTest(BaseTestSessionStorage, unittest.TestCase):
     backend = redis_backend
 
-    def test_ping_returns_an_error_if_unavailable(self):
-        self.session._client.setex = mock.MagicMock(
+    def __init__(self, *args, **kwargs):
+        super(RedisSessionStorageTest, self).__init__(*args, **kwargs)
+        self.client_error_patcher = mock.patch.object(
+            self.session._client,
+            'execute_command',
             side_effect=redis.RedisError)
-        self.assertFalse(self.session.ping())
 
 
 class PostgreSQLSessionStorageTest(BaseTestSessionStorage, unittest.TestCase):
@@ -99,10 +124,11 @@ class PostgreSQLSessionStorageTest(BaseTestSessionStorage, unittest.TestCase):
             'postgres://postgres:postgres@localhost:5432/testdb'
     }
 
-    def test_ping_returns_an_error_if_unavailable(self):
-        with mock.patch.object(self.session, 'connect',
-                               side_effect=psycopg2.OperationalError):
-            self.assertFalse(self.session.ping())
+    def __init__(self, *args, **kwargs):
+        super(PostgreSQLSessionStorageTest, self).__init__(*args, **kwargs)
+        self.client_error_patcher = mock.patch(
+            'cliquet.storage.postgresql.psycopg2.connect',
+            side_effect=psycopg2.OperationalError)
 
 
 class SessionCacheTest(unittest.TestCase):

--- a/cliquet/tests/test_session.py
+++ b/cliquet/tests/test_session.py
@@ -133,7 +133,7 @@ class PostgreSQLSessionStorageTest(BaseTestSessionStorage, unittest.TestCase):
 
 class SessionCacheTest(unittest.TestCase):
     def setUp(self):
-        self.cache = SessionCache(redis_backend.RedisSessionStorage(), 0.05)
+        self.cache = SessionCache(redis_backend.Redis(), 0.05)
         super(SessionCacheTest, self).setUp()
 
     def test_set_adds_the_record(self):

--- a/cliquet/tests/test_storage.py
+++ b/cliquet/tests/test_storage.py
@@ -11,8 +11,6 @@ from cliquet.storage import (
 )
 from cliquet import utils
 from cliquet import schema
-from pyramid import httpexceptions
-from pyramid.config import global_registries
 
 from .support import unittest, ThreadMixin
 

--- a/cliquet/tests/test_storage.py
+++ b/cliquet/tests/test_storage.py
@@ -64,16 +64,53 @@ class BaseTestStorage(object):
         self.user_id = '1234'
         self.other_user_id = '5678'
         self.record = {'foo': 'bar'}
+        self.client_error_patcher = None
 
-    def _get_config(self):
+    def _get_config(self, settings=None):
         """Mock Pyramid config object.
         """
-        return mock.Mock(registry=mock.Mock(settings=self.settings))
+        if settings is None:
+            settings = self.settings
+        return mock.Mock(registry=mock.Mock(settings=settings))
 
     def tearDown(self):
+        mock.patch.stopall()
         super(BaseTestStorage, self).tearDown()
         self.storage.flush()
         self.resource.mapping = TestMapping()
+
+    def test_raises_backend_error_if_error_occurs_on_client(self):
+        self.client_error_patcher.start()
+        self.assertRaises(exceptions.BackendError,
+                          self.storage.get_all,
+                          self.resource, self.user_id)
+
+    def test_backend_error_provides_original_exception(self):
+        self.client_error_patcher.start()
+        try:
+            self.storage.get_all(self.resource, self.user_id)
+        except exceptions.BackendError as e:
+            error = e
+        self.assertTrue(isinstance(error.original, Exception))
+
+    def test_backend_error_is_raised_anywhere(self):
+        self.client_error_patcher.start()
+        calls = [
+            (self.storage.flush,),
+            (self.storage.collection_timestamp, self.resource, self.user_id),
+            (self.storage.create, self.resource, self.user_id, {}),
+            (self.storage.get, self.resource, self.user_id, ''),
+            (self.storage.update, self.resource, self.user_id, '', {}),
+            (self.storage.delete, self.resource, self.user_id, ''),
+            (self.storage.delete_all, self.resource, self.user_id),
+            (self.storage.get_all, self.resource, self.user_id),
+        ]
+        for call in calls:
+            self.assertRaises(exceptions.BackendError, *call)
+
+    def test_ping_returns_an_error_if_unavailable(self):
+        self.client_error_patcher.start()
+        self.assertFalse(self.storage.ping())
 
     def test_ping_returns_true_when_working(self):
         self.assertTrue(self.storage.ping())
@@ -620,6 +657,20 @@ class StorageTest(ThreadMixin,
 class MemoryStorageTest(StorageTest, unittest.TestCase):
     backend = memory
 
+    def __init__(self, *args, **kwargs):
+        super(MemoryStorageTest, self).__init__(*args, **kwargs)
+        self.client_error_patcher = mock.Mock(
+            side_effect=exceptions.BackendError)
+
+    def test_backend_error_provides_original_exception(self):
+        pass
+
+    def test_raises_backend_error_if_error_occurs_on_client(self):
+        pass
+
+    def test_backend_error_is_raised_anywhere(self):
+        pass
+
     def test_ping_returns_an_error_if_unavailable(self):
         pass
 
@@ -636,6 +687,27 @@ class MemoryStorageTest(StorageTest, unittest.TestCase):
 class RedisStorageTest(MemoryStorageTest, unittest.TestCase):
     backend = redisbackend
 
+    def __init__(self, *args, **kwargs):
+        super(RedisStorageTest, self).__init__(*args, **kwargs)
+        self.client_error_patcher = mock.patch.object(
+            self.storage._client,
+            'execute_command',
+            side_effect=redis.RedisError)
+
+    def test_ping_returns_an_error_if_unavailable(self):
+        StorageTest.test_ping_returns_an_error_if_unavailable(self)
+
+    def test_backend_error_provides_original_exception(self):
+        StorageTest.test_backend_error_provides_original_exception(self)
+
+    def test_raises_backend_error_if_error_occurs_on_client(self):
+        StorageTest.test_raises_backend_error_if_error_occurs_on_client(self)
+
+    def test_backend_error_is_raised_anywhere(self):
+        with mock.patch.object(self.storage._client, 'pipeline',
+                               side_effect=redis.RedisError):
+            StorageTest.test_backend_error_is_raised_anywhere(self)
+
     def test_get_all_handle_expired_values(self):
         record = '{"id": "foo"}'.encode('utf-8')
         mocked_smember = mock.patch.object(self.storage._client, "smembers",
@@ -646,11 +718,6 @@ class RedisStorageTest(MemoryStorageTest, unittest.TestCase):
             with mocked_mget:
                 self.storage.get_all(TestResource(), "alexis")  # not raising
 
-    def test_ping_returns_an_error_if_unavailable(self):
-        self.storage._client.setex = mock.MagicMock(
-            side_effect=redis.RedisError)
-        self.assertFalse(self.storage.ping())
-
 
 class PostgresqlStorageTest(StorageTest, unittest.TestCase):
     backend = postgresql
@@ -659,10 +726,11 @@ class PostgresqlStorageTest(StorageTest, unittest.TestCase):
             'postgres://postgres:postgres@localhost:5432/testdb'
     }
 
-    def test_ping_returns_an_error_if_unavailable(self):
-        with mock.patch('cliquet.storage.postgresql.psycopg2.connect',
-                        side_effect=psycopg2.DatabaseError):
-            self.assertFalse(self.storage.ping())
+    def __init__(self, *args, **kwargs):
+        super(PostgresqlStorageTest, self).__init__(*args, **kwargs)
+        self.client_error_patcher = mock.patch(
+            'cliquet.storage.postgresql.psycopg2.connect',
+            side_effect=psycopg2.DatabaseError)
 
     def test_ping_updates_a_value_in_the_metadata_table(self):
         query = "SELECT value FROM metadata WHERE name='last_heartbeat';"
@@ -680,16 +748,6 @@ class PostgresqlStorageTest(StorageTest, unittest.TestCase):
             self.backend.load_from_config(self._get_config())
             message, = mocked.call_args[0]
             self.assertEqual(message, "Detected PostgreSQL storage tables")
-
-    def test_assert_raises_503_when_connection_fails(self):
-        # 503 error relies on Pyramid last registry hook
-        global_registries.add(self._get_config().registry)
-
-        with mock.patch('cliquet.storage.postgresql.PostgreSQL._check_unicity',
-                        side_effect=psycopg2.OperationalError):
-            self.assertRaises(httpexceptions.HTTPServiceUnavailable,
-                              self.storage.create,
-                              self.resource, 'foo', {})
 
     def test_number_of_fetched_records_can_be_limited_in_settings(self):
         for i in range(4):

--- a/cliquet/views/errors.py
+++ b/cliquet/views/errors.py
@@ -9,6 +9,7 @@ from pyramid.view import (
 
 from cliquet import logger
 from cliquet.errors import http_error, ERRORS
+from cliquet.storage import exceptions as storage_exceptions
 from cliquet.utils import reapply_cors
 
 
@@ -82,6 +83,10 @@ def error(context, request):
     """Catch server errors and trace them."""
     if isinstance(context, httpexceptions.Response):
         return reapply_cors(request, context)
+
+    if isinstance(context, storage_exceptions.BackendError):
+        logger.exception(context.original)
+        return service_unavailable(context, request)
 
     logger.exception(context)
 


### PR DESCRIPTION
fixes #21 

* [x] Define BackendError exception
* [x] Make sure all storage client code is wrapped to catch errors
* [x] Make sure all session client code is wrapped to catch errors
* [x] Bind BackendError to 503 response
* [x] Test that backend errors end up as 503 in views
