### PR TITLE
Bug 1142401 — Remove the redirect querystring parameter to the /fxa-oauth/login endpoint.

### DIFF
--- a/cliquet/__init__.py
+++ b/cliquet/__init__.py
@@ -37,6 +37,8 @@ DEFAULT_SETTINGS = {
     'fxa-oauth.client_secret': None,
     'fxa-oauth.oauth_uri': None,
     'fxa-oauth.scope': 'profile',
+    'fxa-oauth.state.ttl_seconds': 3600,  # 1 hour
+    'fxa-oauth.webapp.redirect_url': '',
     'cliquet.backoff': None,
     'cliquet.basic_auth_enabled': False,
     'cliquet.batch_max_requests': None,

--- a/cliquet/__init__.py
+++ b/cliquet/__init__.py
@@ -38,7 +38,7 @@ DEFAULT_SETTINGS = {
     'fxa-oauth.oauth_uri': None,
     'fxa-oauth.scope': 'profile',
     'fxa-oauth.state.ttl_seconds': 3600,  # 1 hour
-    'fxa-oauth.webapp.redirect_url': '',
+    'fxa-oauth.webapp.authorized_domains': '',
     'cliquet.backoff': None,
     'cliquet.basic_auth_enabled': False,
     'cliquet.batch_max_requests': None,

--- a/cliquet/tests/support.py
+++ b/cliquet/tests/support.py
@@ -95,6 +95,8 @@ class BaseWebTest(FakeAuthentMixin):
         settings['cliquet.project_name'] = 'cliquet'
         settings['cliquet.project_docs'] = 'https://cliquet.rtfd.org/'
         settings['fxa-oauth.oauth_uri'] = 'https://oauth-stable.dev.lcip.org'
+        app_redirect = 'https://readinglist.firefox.com/#token='
+        settings['fxa-oauth.webapp.redirect_url'] = app_redirect
         return settings
 
     def tearDown(self):

--- a/cliquet/tests/support.py
+++ b/cliquet/tests/support.py
@@ -95,8 +95,7 @@ class BaseWebTest(FakeAuthentMixin):
         settings['cliquet.project_name'] = 'cliquet'
         settings['cliquet.project_docs'] = 'https://cliquet.rtfd.org/'
         settings['fxa-oauth.oauth_uri'] = 'https://oauth-stable.dev.lcip.org'
-        app_redirect = 'https://readinglist.firefox.com/#token='
-        settings['fxa-oauth.webapp.redirect_url'] = app_redirect
+        settings['fxa-oauth.webapp.authorized_domains'] = ['*.firefox.com', ]
         return settings
 
     def tearDown(self):

--- a/cliquet/tests/test_views_oauth.py
+++ b/cliquet/tests/test_views_oauth.py
@@ -72,6 +72,14 @@ class TokenViewTest(BaseWebTest, unittest.TestCase):
         self.app.get(url, status=401)
 
     @mock.patch('cliquet.views.oauth.OAuthClient.trade_code')
+    def test_fails_if_state_was_already_consumed(self, mocked_trade):
+        mocked_trade.return_value = 'oauth-token'
+        self.app.app.registry.session.set('abc', 'http://foobar')
+        url = '{url}?state=abc&code=1234'.format(url=self.url)
+        self.app.get(url)
+        self.app.get(url, status=401)
+
+    @mock.patch('cliquet.views.oauth.OAuthClient.trade_code')
     def tests_redirects_with_token_traded_against_code(self, mocked_trade):
         mocked_trade.return_value = 'oauth-token'
         self.app.app.registry.session.set('abc', 'http://foobar?token=')

--- a/cliquet/tests/test_views_oauth.py
+++ b/cliquet/tests/test_views_oauth.py
@@ -6,12 +6,7 @@ from .support import BaseWebTest, unittest
 
 
 class LoginViewTest(BaseWebTest, unittest.TestCase):
-    url = '/fxa-oauth/login?redirect=http://perdu.com/'
-
-    def test_redirect_parameter_is_mandatory(self):
-        url = '/fxa-oauth/login'
-        r = self.app.get(url, status=400)
-        self.assertIn('redirect', r.json['message'])
+    url = '/fxa-oauth/login'
 
     def test_login_view_persists_state(self):
         r = self.app.get(self.url)
@@ -20,7 +15,7 @@ class LoginViewTest(BaseWebTest, unittest.TestCase):
         queryparams = parse_qs(url_fragments.query)
         state = queryparams['state'][0]
         self.assertEqual(self.app.app.registry.session.get(state),
-                         'http://perdu.com/')
+                         'https://readinglist.firefox.com/#token=')
 
     @mock.patch('cliquet.views.oauth.uuid.uuid4')
     def test_login_view_redirects_to_authorization(self, mocked_uuid):

--- a/cliquet/views/oauth.py
+++ b/cliquet/views/oauth.py
@@ -1,5 +1,5 @@
 import uuid
-import urlparse
+from six.moves.urllib.parse import urlparse
 from fnmatch import fnmatch
 
 from cornice import Service
@@ -55,7 +55,7 @@ def authorized_redirect(req):
     if 'redirect' not in req.validated:
         return True
 
-    domain = urlparse.urlparse(req.validated['redirect']).netloc
+    domain = urlparse(req.validated['redirect']).netloc
 
     if not any((fnmatch(domain, auth) for auth in authorized)):
         req.errors.add('querystring', 'redirect',

--- a/cliquet/views/oauth.py
+++ b/cliquet/views/oauth.py
@@ -35,7 +35,7 @@ def fxa_conf(request, name):
 
 def persist_state(request):
     """Persist arbitrary string in session.
-    It will be matched when the user return from the OAuth server login
+    It will be matched when the user returns from the OAuth server login
     page.
     """
     state = uuid.uuid4().hex
@@ -59,7 +59,7 @@ def authorized_redirect(req):
 
     if not any((fnmatch(domain, auth) for auth in authorized)):
         req.errors.add('querystring', 'redirect',
-                       'redirect URL is not whitelisted')
+                       'redirect URL is not authorized')
 
 
 @login.get(schema=FxALoginRequest, permission=NO_PERMISSION_REQUIRED,

--- a/cliquet/views/oauth.py
+++ b/cliquet/views/oauth.py
@@ -23,14 +23,10 @@ token = Service(name='fxa-oauth-token',
                 path='/fxa-oauth/token',
                 error_handler=errors.json_error_handler)
 
-DEFAULT_STATE_EXPIRY_SECONDS = 3600  # 1 hour
 
-
-def fxa_conf(request, name, default=None):
+def fxa_conf(request, name):
     key = 'fxa-oauth.' + name
-    if default is None:
-        return request.registry.settings[key]
-    return request.registry.settings.get(key, default)
+    return request.registry.settings[key]
 
 
 def persist_state(request):
@@ -40,8 +36,7 @@ def persist_state(request):
     state = uuid.uuid4().hex
     redirect_url = fxa_conf(request, 'webapp.redirect_url')
     request.registry.session.set(state, redirect_url)
-    expiration = fxa_conf(request, 'state.ttl_seconds',
-                          DEFAULT_STATE_EXPIRY_SECONDS)
+    expiration = int(fxa_conf(request, 'state.ttl_seconds'))
     request.registry.session.expire(state, expiration)
     return state
 

--- a/cliquet/views/oauth.py
+++ b/cliquet/views/oauth.py
@@ -38,11 +38,11 @@ def persist_state(request):
     It will be compared when return from login page on OAuth server.
     """
     state = uuid.uuid4().hex
-    request.registry.session.set(state,
-                                 fxa_conf(request, 'webapp.redirect_url'))
-    request.registry.session.expire(
-        state,
-        fxa_conf(request, 'state.ttl_seconds', DEFAULT_STATE_EXPIRY_SECONDS))
+    redirect_url = fxa_conf(request, 'webapp.redirect_url')
+    request.registry.session.set(state, redirect_url)
+    expiration = fxa_conf(request, 'state.ttl_seconds',
+                          DEFAULT_STATE_EXPIRY_SECONDS)
+    request.registry.session.expire(state, expiration)
     return state
 
 

--- a/cliquet/views/oauth.py
+++ b/cliquet/views/oauth.py
@@ -9,7 +9,6 @@ from pyramid import httpexceptions
 from pyramid.security import NO_PERMISSION_REQUIRED
 
 from cliquet import errors
-from cliquet.schema import URL
 from cliquet.views.errors import authorization_required
 from cliquet import logger
 
@@ -34,15 +33,12 @@ def persist_state(request):
     It will be compared when return from login page on OAuth server.
     """
     state = uuid.uuid4().hex
-    request.registry.session.set(state, request.validated['redirect'])
+    request.registry.session.set(state,
+                                 fxa_conf(request, 'webapp.redirect_url'))
     return state
 
 
-class FxALoginRequest(MappingSchema):
-    redirect = URL(location="querystring")
-
-
-@login.get(schema=FxALoginRequest, permission=NO_PERMISSION_REQUIRED)
+@login.get(permission=NO_PERMISSION_REQUIRED)
 def fxa_oauth_login(request):
     """Helper to redirect client towards FxA login form."""
     state = persist_state(request)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -159,3 +159,4 @@ If you're a Mozilla service, fill the settings with the values you were provided
     fxa-oauth.oauth_uri = https://oauth-stable.dev.lcip.org
     fxa-oauth.scope = profile
     fxa-oauth.webapp.redirect_url = https://readinglist.firefox.com/#auth:
+    # fxa-oauth.state.ttl_seconds = 300

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -158,3 +158,4 @@ If you're a Mozilla service, fill the settings with the values you were provided
     fxa-oauth.client_secret = 9aced230585cc0aaea0a3467dd800
     fxa-oauth.oauth_uri = https://oauth-stable.dev.lcip.org
     fxa-oauth.scope = profile
+    fxa-oauth.webapp.redirect_url = https://readinglist.firefox.com/#auth:

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -158,5 +158,5 @@ If you're a Mozilla service, fill the settings with the values you were provided
     fxa-oauth.client_secret = 9aced230585cc0aaea0a3467dd800
     fxa-oauth.oauth_uri = https://oauth-stable.dev.lcip.org
     fxa-oauth.scope = profile
-    fxa-oauth.webapp.redirect_url_whitelist = firefox.com
+    fxa-oauth.webapp.redirect_url_whitelist = *.firefox.com
     # fxa-oauth.state.ttl_seconds = 300

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -158,5 +158,5 @@ If you're a Mozilla service, fill the settings with the values you were provided
     fxa-oauth.client_secret = 9aced230585cc0aaea0a3467dd800
     fxa-oauth.oauth_uri = https://oauth-stable.dev.lcip.org
     fxa-oauth.scope = profile
-    fxa-oauth.webapp.redirect_url_whitelist = *.firefox.com
+    fxa-oauth.webapp.authorized_domains = *.firefox.com
     # fxa-oauth.state.ttl_seconds = 300

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -158,5 +158,5 @@ If you're a Mozilla service, fill the settings with the values you were provided
     fxa-oauth.client_secret = 9aced230585cc0aaea0a3467dd800
     fxa-oauth.oauth_uri = https://oauth-stable.dev.lcip.org
     fxa-oauth.scope = profile
-    fxa-oauth.webapp.redirect_url = https://readinglist.firefox.com/#auth:
+    fxa-oauth.webapp.redirect_url_whitelist = firefox.com
     # fxa-oauth.state.ttl_seconds = 300


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1142401