### PR TITLE
Consider storing the raw FxA uid, rather than hmacing it

### DIFF
--- a/cliquet/authentication.py
+++ b/cliquet/authentication.py
@@ -71,10 +71,7 @@ class Oauth2AuthenticationPolicy(base_auth.CallbackAuthenticationPolicy):
         auth_client = OAuthClient(server_url=server_url, cache=self.cache)
         try:
             profile = auth_client.verify_token(token=auth, scope=scope)
-            hmac_secret = settings.get('cliquet.userid_hmac_secret')
-            user_id = hmac.new(hmac_secret.encode('utf-8'),
-                               profile['user'].encode('utf-8'),
-                               hashlib.sha256).hexdigest()
+            user_id = profile['user'].encode('utf-8')
         except fxa_errors.OutOfProtocolError:
             raise httpexceptions.HTTPServiceUnavailable()
         except (fxa_errors.InProtocolError, fxa_errors.TrustError):


### PR DESCRIPTION
While poking around in service of Bug 1141166 [1] I noticed that you're hmacing the FxA uid rather than storing it directly:

  https://github.com/mozilla-services/cliquet/blob/master/cliquet/authentication.py#L75

I assume this is intended to obfuscate it for privay purposes?

We generally haven't been treating the account uid as private, and are encouraging reliers/providers to just use it directly as the primary identifier for the account.  You might consider saving a bit of code and ops complexity by just storing it directly.

Having the raw uid could also be useful if you e.g. you want to publish notification events for other reliers via the upcoming https://github.com/mozilla/fxa-notification-server.

[1] https://bugzilla.mozilla.org/show_bug.cgi?id=1141166