### PR TITLE
Set default limit for number of requests in batch

### DIFF
--- a/cliquet/__init__.py
+++ b/cliquet/__init__.py
@@ -39,7 +39,7 @@ DEFAULT_SETTINGS = {
     'fxa-oauth.scope': 'profile',
     'cliquet.backoff': None,
     'cliquet.basic_auth_enabled': False,
-    'cliquet.batch_max_requests': None,
+    'cliquet.batch_max_requests': 25,
     'cliquet.delete_collection_enabled': True,
     'cliquet.eos': None,
     'cliquet.eos_message': None,

--- a/cliquet/storage/cloud_storage.py
+++ b/cliquet/storage/cloud_storage.py
@@ -218,7 +218,7 @@ class CloudStorage(StorageBase):
             for filters in pagination_rules:
                 params_ = list(params)
                 params_ += [("%s%s" % (FILTERS[op], k), v)
-                              for k, v, op in filters]
+                            for k, v, op in filters]
                 querystring = '&'.join(['%s=%s' % (p, v) for p, v in params_])
                 batch_payload['requests'].append({
                     'path': url + '?%s' % querystring,


### PR DESCRIPTION
Currently if the setting `cliquet.batch_max_requests` is not set, there is no limit.

We could set a default value (e.g. 25 ?). 

I would wait for #27 to be merged before changing this.