### PR TITLE
Get rid of useless http_scheme setting

### DIFF
--- a/cliquet/__init__.py
+++ b/cliquet/__init__.py
@@ -55,7 +55,6 @@ DEFAULT_SETTINGS = {
     'cliquet.eos_message': None,
     'cliquet.eos_url': None,
     'cliquet.logging_renderer': 'cliquet.logs.ClassicLogRenderer',
-    'cliquet.http_scheme': None,
     'cliquet.paginate_by': None,
     'cliquet.project_docs': '',
     'cliquet.project_name': '',
@@ -144,11 +143,6 @@ def attach_http_objects(config):
         # Attach objects on requests for easier access.
         event.request.db = config.registry.storage
         event.request.cache = config.registry.cache
-
-        # Force request scheme from settings.
-        http_scheme = config.registry.settings['cliquet.http_scheme']
-        if http_scheme:
-            event.request.scheme = http_scheme
 
     config.add_subscriber(on_new_request, NewRequest)
 

--- a/cliquet/tests/config/kinto.ini
+++ b/cliquet/tests/config/kinto.ini
@@ -6,7 +6,6 @@ cliquet.project_docs = https://kinto.rtfd.org/
 cliquet.cache_backend = cliquet.cache.redis
 cliquet.storage_backend = cliquet.storage.postgresql
 cliquet.storage_url = postgres://postgres:postgres@localhost/postgres
-cliquet.http_scheme = http
 cliquet.retry_after = 30
 cliquet.basic_auth_enabled = true
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -48,7 +48,6 @@ Deployment
 .. code-block :: ini
 
     # cliquet.backoff = 10
-    cliquet.http_scheme = https
     cliquet.retry_after_seconds = 30
 
 Deprecation


### PR DESCRIPTION
I want to remove the ``cliquet.http_scheme`` setting for the following reasons:

* Less is more
* Tests did not break when I took it out (*untested code does not exist.*)
* It is *cliquet* specific, and gives the impression that we do some magic with it, whereas WSGI and Pyramid already manage this stuff
* It is unclear whether changing requests attributes will truely override Pyramid internal machinery on URLs (which partly relies on WSGI environs)
* It was not at the right place (``attach_http_objects``)

I suggest we had some documentation and highlight pitfalls of WSGI apps proxifying instead... such as for Nginx: 

```
        proxy_set_header        Host $http_host;
        proxy_set_header        X-Real-IP $remote_addr;
        proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header        X-Forwarded-Proto $scheme;
```
