### PR TITLE
Ignore precondition headers from batch request

### DIFF
--- a/cliquet/tests/test_views_batch.py
+++ b/cliquet/tests/test_views_batch.py
@@ -93,7 +93,7 @@ class BatchViewTest(BaseWebTest, unittest.TestCase):
 
     def test_preconditions_headers_of_batch_are_ignored(self):
         resp = self.app.get('/mushrooms', headers=self.headers)
-        before = resp.headers['Last-Modified']
+        before = resp.headers['Last-Modified'].decode('utf8')
 
         request = {'path': '/mushrooms',
                    'method': 'POST',
@@ -109,7 +109,7 @@ class BatchViewTest(BaseWebTest, unittest.TestCase):
 
     def test_preconditions_headers_within_batch_are_respected(self):
         resp = self.app.get('/mushrooms', headers=self.headers)
-        before = resp.headers['Last-Modified']
+        before = resp.headers['Last-Modified'].decode('utf8')
 
         request = {'path': '/mushrooms',
                    'method': 'POST',

--- a/cliquet/tests/test_views_batch.py
+++ b/cliquet/tests/test_views_batch.py
@@ -91,6 +91,22 @@ class BatchViewTest(BaseWebTest, unittest.TestCase):
         self.assertEqual(hello['body']['hello'], 'cliquet')
         self.assertIn('application/json', hello['headers']['Content-Type'])
 
+    def test_preconditions_headers_are_ignored(self):
+        resp = self.app.get('/mushrooms', headers=self.headers)
+        before = resp.headers['Last-Modified']
+
+        request = {'path': '/mushrooms',
+                   'method': 'POST',
+                   'body': {'name': 'Champignon'}}
+        body = {'requests': [request, request]}
+
+        headers = self.headers.copy()
+        headers['If-Unmodified-Since'] = before
+        resp = self.app.post_json('/batch', body, headers=headers)
+        responses = resp.json['responses']
+        self.assertEqual(responses[0]['status'], 201)
+        self.assertEqual(responses[1]['status'], 201)
+
 
 class BatchSchemaTest(unittest.TestCase):
     def setUp(self):

--- a/cliquet/views/batch.py
+++ b/cliquet/views/batch.py
@@ -142,6 +142,8 @@ def build_request(original, dict_obj):
 
     method = dict_obj.get('method') or 'GET'
     headers = dict(original.headers)
+    headers.pop('If-Modified-Since', None)
+    headers.pop('If-Unmodified-Since', None)
     headers.update(**dict_obj.get('headers') or {})
     payload = dict_obj.get('body') or ''
 


### PR DESCRIPTION
One possible fix for https://bugzilla.mozilla.org/show_bug.cgi?id=1148201 (https://github.com/mozilla-services/readinglist/issues/225)

@Natim suggested to throw a 400 instead, if ``If-Modified-Since`` or ``If-Unmodified-Since`` are set on a ``POST /batch`` request. Indeed, if those headers are necessary for the operations within the batch, then they should be specified on requests definitions in the JSON batch payload, not in the headers of the batch request itself.