### PR TITLE
Warn if PostgreSQL user is not UTC (ref #177)

### DIFF
--- a/cliquet/storage/postgresql/__init__.py
+++ b/cliquet/storage/postgresql/__init__.py
@@ -1,5 +1,6 @@
 import contextlib
 import os
+import warnings
 from collections import defaultdict
 
 import psycopg2
@@ -112,33 +113,42 @@ class PostgreSQL(PostgreSQLClient, StorageBase):
                                           globally=True,
                                           loads=json.loads)
 
+    def _execute_sql_file(self, filepath):
+        here = os.path.abspath(os.path.dirname(__file__))
+        schema = open(os.path.join(here, 'schema.sql')).read()
+        with self.connect() as cursor:
+            cursor.execute(schema)
+
     def _init_schema(self):
         """Create PostgreSQL tables, only if not exists.
 
         :note:
             Relies on JSON fields, available in recent versions of PostgreSQL.
         """
-        # Since indices cannot be created with IF NOT EXISTS, inspect.
-        query = """
-        SELECT *
-          FROM pg_tables
-         WHERE tablename = 'records';
-        """
-        with self.connect() as cursor:
-            cursor.execute(query)
-            exists = cursor.rowcount > 0
-
-        # Force user timezone
-        user = self._conn_kwargs.get('user')
-        if user:
-            with self.connect() as cursor:
-                cursor.execute("ALTER ROLE %s SET TIME ZONE 'UTC';" % user)
-
-        if exists:
+        version = self._get_installed_version()
+        if version:
             logger.debug('Detected PostgreSQL storage tables')
             return
 
-        # Make sure database is UTF-8
+        # Check database config.
+        self._check_database_encoding()
+        self._check_database_timezone()
+        # Create full schema.
+        self._execute_sql_file('schema.sql')
+        logger.info('Created PostgreSQL storage tables.')
+
+    def _check_database_timezone(self):
+        # Make sure database has UTC timezone.
+        query = "SELECT current_setting('TIMEZONE') AS timezone;"
+        with self.connect() as cursor:
+            cursor.execute(query)
+            result = cursor.fetchone()
+        timezone = result['timezone'].upper()
+        if timezone != 'UTC':
+            warnings.warn('Database timezone is not UTC (%s)' % timezone)
+
+    def _check_database_encoding(self):
+        # Make sure database is UTF-8.
         query = """
         SELECT pg_encoding_to_char(encoding) AS encoding
           FROM pg_database
@@ -150,12 +160,14 @@ class PostgreSQL(PostgreSQLClient, StorageBase):
         encoding = result['encoding'].lower()
         assert encoding == 'utf8', 'Unexpected database encoding %s' % encoding
 
-        # Create schema
-        here = os.path.abspath(os.path.dirname(__file__))
-        schema = open(os.path.join(here, 'schema.sql')).read()
+    def _get_installed_version(self):
+        query = "SELECT * FROM pg_tables WHERE tablename = 'records';"
         with self.connect() as cursor:
-            cursor.execute(schema)
-        logger.info('Created PostgreSQL storage tables')
+            cursor.execute(query)
+            tables_exist = cursor.rowcount > 0
+
+        if tables_exist:
+            return 1
 
     def flush(self):
         """Delete records from tables without destroying schema. Mainly used

--- a/cliquet/tests/test_storage.py
+++ b/cliquet/tests/test_storage.py
@@ -816,6 +816,17 @@ class PostgresqlStorageTest(StorageTest, unittest.TestCase):
             message, = mocked.call_args[0]
             self.assertEqual(message, "Detected PostgreSQL storage tables")
 
+    def test_warns_if_database_is_not_utc(self):
+        with self.storage.connect() as cursor:
+            cursor.execute("ALTER ROLE postgres SET TIME ZONE 'Europe/Paris';")
+
+        with mock.patch('cliquet.storage.postgresql.warnings.warn') as mocked:
+            self.backend.load_from_config(self._get_config())
+            mocked.assert_called()
+
+        with self.storage.connect() as cursor:
+            cursor.execute("ALTER ROLE postgres SET TIME ZONE 'UTC';")
+
     def test_number_of_fetched_records_can_be_limited_in_settings(self):
         for i in range(4):
             self.create_record({'phone': 'tel-%s' % i})


### PR DESCRIPTION
Instead of altering user on each startup, check and warns during first schema creation.

Contrary to UTF8 setting, this is not a mandatory setting, but a recommandation.