### PR TITLE
Use ordered index to improve PG performances (ref #138)

### DIFF
--- a/cliquet/storage/postgresql/__init__.py
+++ b/cliquet/storage/postgresql/__init__.py
@@ -123,7 +123,7 @@ class PostgreSQL(PostgreSQLClient, StorageBase):
 
     """
 
-    schema_version = 2
+    schema_version = 3
 
     def __init__(self, *args, **kwargs):
         self._max_fetch_size = kwargs.pop('max_fetch_size')

--- a/cliquet/storage/postgresql/__init__.py
+++ b/cliquet/storage/postgresql/__init__.py
@@ -183,7 +183,9 @@ class PostgreSQL(PostgreSQLClient, StorageBase):
             result = cursor.fetchone()
         timezone = result['timezone'].upper()
         if timezone != 'UTC':  # pragma: no cover
-            warnings.warn('Database timezone is not UTC (%s)' % timezone)
+            msg = 'Database timezone is not UTC (%s)' % timezone
+            warnings.warn(msg)
+            logger.warning(msg)
 
     def _check_database_encoding(self):
         # Make sure database is UTF-8.
@@ -258,6 +260,7 @@ class PostgreSQL(PostgreSQLClient, StorageBase):
                             data=json.dumps(record))
 
         with self.connect() as cursor:
+            # Check that it does violate the resource unicity rules.
             self._check_unicity(cursor, resource, user_id, record)
 
             cursor.execute(query, placeholders)
@@ -308,6 +311,7 @@ class PostgreSQL(PostgreSQLClient, StorageBase):
                             data=json.dumps(record))
 
         with self.connect() as cursor:
+            # Check that it does violate the resource unicity rules.
             self._check_unicity(cursor, resource, user_id, record)
 
             # Create or update ?

--- a/cliquet/storage/postgresql/migrations/migration_002_003.sql
+++ b/cliquet/storage/postgresql/migrations/migration_002_003.sql
@@ -1,0 +1,33 @@
+ALTER TABLE records DROP CONSTRAINT records_id_user_id_resource_name_last_modified_key CASCADE;
+CREATE UNIQUE INDEX idx_records_user_id_resource_name_last_modified
+    ON records(user_id, resource_name, last_modified DESC);
+
+ALTER TABLE deleted DROP CONSTRAINT deleted_id_user_id_resource_name_last_modified_key CASCADE;
+CREATE UNIQUE INDEX idx_deleted_user_id_resource_name_last_modified
+    ON deleted(user_id, resource_name, last_modified DESC);
+
+CREATE OR REPLACE FUNCTION resource_timestamp(uid VARCHAR, resource VARCHAR)
+RETURNS TIMESTAMP AS $$
+DECLARE
+    ts_records TIMESTAMP;
+    ts_deleted TIMESTAMP;
+BEGIN
+    SELECT last_modified INTO ts_records
+      FROM records
+     WHERE user_id = uid
+       AND resource_name = resource
+     ORDER BY last_modified DESC LIMIT 1;
+
+    SELECT last_modified INTO ts_deleted
+      FROM deleted
+     WHERE user_id = uid
+       AND resource_name = resource
+     ORDER BY last_modified DESC LIMIT 1;
+
+    -- Latest of records/deleted or current if empty
+    RETURN coalesce(greatest(ts_deleted, ts_records), localtimestamp);
+END;
+$$ LANGUAGE plpgsql;
+
+-- Bump storage schema version.
+INSERT INTO metadata (name, value) VALUES ('storage_schema_version', '3');


### PR DESCRIPTION
ref #138

This changeset boosts insertion of records (x100 faster):

*before ~10ms per insert*

    testdb=# INSERT INTO records(user_id, resource_name, data) SELECT * FROM generate_records(10000, 1, 10);
    INSERT 0 100000
    Time: 1102111,033 ms

*after ~0.1 ms per insert*

    testdb=# INSERT INTO records(user_id, resource_name, data) SELECT * FROM generate_records(100000, 1, 10);
    INSERT 0 1000000
    Time: 109397,719 ms

@Natim @ametaireau could you give a shot locally and see if you notice the same (amazing) improvements ?

Original notes here : https://etherpad.mozilla.org/reading-list-perf-postgres