### PR TITLE
Get rid of redondant indices

### DIFF
--- a/cliquet/storage/postgresql/__init__.py
+++ b/cliquet/storage/postgresql/__init__.py
@@ -538,19 +538,11 @@ class PostgreSQL(PostgreSQLClient, StorageBase):
         holders = {}
         for i, filtr in enumerate(filters):
             value = filtr.value
-            sql_operator = operators.setdefault(filtr.operator, filtr.operator)
-
-            if filtr.field == resource.modified_field:
-                # Value is integer (asserted in resource).
-                assert isinstance(filtr.value, six.integer_types)
-                # Bypass field and value escaping in order to use a function.
-                cond = "last_modified %s from_epoch(%s)" % (sql_operator,
-                                                            filtr.value)
-                conditions.append(cond)
-                continue
 
             if filtr.field == resource.id_field:
                 sql_field = 'id'
+            elif filtr.field == resource.modified_field:
+                sql_field = 'as_epoch(last_modified)'
             else:
                 # Safely escape field name
                 field_holder = '%s_field_%s' % (prefix, i)
@@ -566,6 +558,7 @@ class PostgreSQL(PostgreSQLClient, StorageBase):
             value_holder = '%s_value_%s' % (prefix, i)
             holders[value_holder] = value
 
+            sql_operator = operators.setdefault(filtr.operator, filtr.operator)
             cond = "%s %s %%(%s)s" % (sql_field, sql_operator, value_holder)
             conditions.append(cond)
 

--- a/cliquet/storage/postgresql/migrations/migration_004_005.sql
+++ b/cliquet/storage/postgresql/migrations/migration_004_005.sql
@@ -1,0 +1,28 @@
+CREATE OR REPLACE FUNCTION from_epoch(ts BIGINT) RETURNS TIMESTAMP AS $$
+BEGIN
+    RETURN to_timestamp(ts / 1000.0) AT TIME ZONE 'UTC';
+END;
+$$ LANGUAGE plpgsql
+IMMUTABLE;
+
+
+DROP INDEX IF EXISTS idx_records_user_id;
+DROP INDEX IF EXISTS idx_records_resource_name;
+DROP INDEX IF EXISTS idx_records_last_modified;
+DROP INDEX IF EXISTS idx_records_id;
+
+ALTER TABLE records
+    ADD PRIMARY KEY (id, user_id, resource_name);
+
+
+DROP INDEX IF EXISTS idx_deleted_id;
+DROP INDEX IF EXISTS idx_deleted_user_id;
+DROP INDEX IF EXISTS idx_deleted_resource_name;
+DROP INDEX IF EXISTS idx_deleted_last_modified;
+
+ALTER TABLE deleted
+    ADD PRIMARY KEY (id, user_id, resource_name);
+
+
+-- Bump storage schema version.
+INSERT INTO metadata (name, value) VALUES ('storage_schema_version', '5');

--- a/cliquet/storage/postgresql/migrations/migration_004_005.sql
+++ b/cliquet/storage/postgresql/migrations/migration_004_005.sql
@@ -1,15 +1,6 @@
-CREATE OR REPLACE FUNCTION from_epoch(ts BIGINT) RETURNS TIMESTAMP AS $$
-BEGIN
-    RETURN to_timestamp(ts / 1000.0) AT TIME ZONE 'UTC';
-END;
-$$ LANGUAGE plpgsql
-IMMUTABLE;
-
-
 DROP INDEX IF EXISTS idx_records_user_id;
 DROP INDEX IF EXISTS idx_records_resource_name;
 DROP INDEX IF EXISTS idx_records_last_modified;
-DROP INDEX IF EXISTS idx_records_last_modified_epoch;
 DROP INDEX IF EXISTS idx_records_id;
 
 ALTER TABLE records
@@ -20,7 +11,6 @@ DROP INDEX IF EXISTS idx_deleted_id;
 DROP INDEX IF EXISTS idx_deleted_user_id;
 DROP INDEX IF EXISTS idx_deleted_resource_name;
 DROP INDEX IF EXISTS idx_deleted_last_modified;
-DROP INDEX IF EXISTS idx_deleted_last_modified_epoch;
 
 ALTER TABLE deleted
     ADD PRIMARY KEY (id, user_id, resource_name);

--- a/cliquet/storage/postgresql/migrations/migration_004_005.sql
+++ b/cliquet/storage/postgresql/migrations/migration_004_005.sql
@@ -9,6 +9,7 @@ IMMUTABLE;
 DROP INDEX IF EXISTS idx_records_user_id;
 DROP INDEX IF EXISTS idx_records_resource_name;
 DROP INDEX IF EXISTS idx_records_last_modified;
+DROP INDEX IF EXISTS idx_records_last_modified_epoch;
 DROP INDEX IF EXISTS idx_records_id;
 
 ALTER TABLE records
@@ -19,6 +20,7 @@ DROP INDEX IF EXISTS idx_deleted_id;
 DROP INDEX IF EXISTS idx_deleted_user_id;
 DROP INDEX IF EXISTS idx_deleted_resource_name;
 DROP INDEX IF EXISTS idx_deleted_last_modified;
+DROP INDEX IF EXISTS idx_deleted_last_modified_epoch;
 
 ALTER TABLE deleted
     ADD PRIMARY KEY (id, user_id, resource_name);

--- a/cliquet/storage/postgresql/schema.sql
+++ b/cliquet/storage/postgresql/schema.sql
@@ -8,6 +8,13 @@ END;
 $$ LANGUAGE plpgsql
 IMMUTABLE;
 
+CREATE OR REPLACE FUNCTION from_epoch(ts BIGINT) RETURNS TIMESTAMP AS $$
+BEGIN
+    RETURN to_timestamp(ts / 1000.0) AT TIME ZONE 'UTC';
+END;
+$$ LANGUAGE plpgsql
+IMMUTABLE;
+
 --
 -- Actual records
 --
@@ -30,8 +37,6 @@ CREATE TABLE IF NOT EXISTS records (
 DROP INDEX IF EXISTS idx_records_user_id_resource_name_last_modified;
 CREATE UNIQUE INDEX idx_records_user_id_resource_name_last_modified
     ON records(user_id, resource_name, last_modified DESC);
-DROP INDEX IF EXISTS idx_records_last_modified_epoch;
-CREATE INDEX idx_records_last_modified_epoch ON records(as_epoch(last_modified));
 
 
 --
@@ -48,8 +53,6 @@ CREATE TABLE IF NOT EXISTS deleted (
 DROP INDEX IF EXISTS idx_records_user_id_resource_name_last_modified;
 CREATE UNIQUE INDEX idx_records_user_id_resource_name_last_modified
     ON records(user_id, resource_name, last_modified DESC);
-DROP INDEX IF EXISTS idx_deleted_last_modified_epoch;
-CREATE INDEX idx_deleted_last_modified_epoch ON deleted(as_epoch(last_modified));
 
 
 --

--- a/cliquet/storage/postgresql/schema.sql
+++ b/cliquet/storage/postgresql/schema.sql
@@ -22,22 +22,16 @@ CREATE TABLE IF NOT EXISTS records (
     last_modified TIMESTAMP NOT NULL,
 
     -- Consider using binary JSON (JSONB, postgresql 9.4+, 2x faster).
-    data JSON NOT NULL DEFAULT '{}'
+    data JSON NOT NULL DEFAULT '{}',
+
+    PRIMARY KEY (id, user_id, resource_name)
 );
 
 DROP INDEX IF EXISTS idx_records_user_id_resource_name_last_modified;
 CREATE UNIQUE INDEX idx_records_user_id_resource_name_last_modified
     ON records(user_id, resource_name, last_modified DESC);
-DROP INDEX IF EXISTS idx_records_user_id;
-CREATE INDEX idx_records_user_id ON records(user_id);
-DROP INDEX IF EXISTS idx_records_resource_name;
-CREATE INDEX idx_records_resource_name ON records(resource_name);
-DROP INDEX IF EXISTS idx_records_last_modified;
-CREATE INDEX idx_records_last_modified ON records(last_modified);
 DROP INDEX IF EXISTS idx_records_last_modified_epoch;
 CREATE INDEX idx_records_last_modified_epoch ON records(as_epoch(last_modified));
-DROP INDEX IF EXISTS idx_records_id;
-CREATE INDEX idx_records_id ON records(id);
 
 
 --
@@ -47,21 +41,16 @@ CREATE TABLE IF NOT EXISTS deleted (
     id TEXT NOT NULL,
     user_id TEXT NOT NULL,
     resource_name TEXT NOT NULL,
-    last_modified TIMESTAMP NOT NULL
+    last_modified TIMESTAMP NOT NULL,
+
+    PRIMARY KEY (id, user_id, resource_name)
 );
 DROP INDEX IF EXISTS idx_records_user_id_resource_name_last_modified;
 CREATE UNIQUE INDEX idx_records_user_id_resource_name_last_modified
     ON records(user_id, resource_name, last_modified DESC);
-DROP INDEX IF EXISTS idx_deleted_id;
-CREATE UNIQUE INDEX idx_deleted_id ON deleted(id);
-DROP INDEX IF EXISTS idx_deleted_user_id;
-CREATE INDEX idx_deleted_user_id ON deleted(user_id);
-DROP INDEX IF EXISTS idx_deleted_resource_name;
-CREATE INDEX idx_deleted_resource_name ON deleted(resource_name);
-DROP INDEX IF EXISTS idx_deleted_last_modified;
-CREATE INDEX idx_deleted_last_modified ON deleted(last_modified);
 DROP INDEX IF EXISTS idx_deleted_last_modified_epoch;
 CREATE INDEX idx_deleted_last_modified_epoch ON deleted(as_epoch(last_modified));
+
 
 --
 -- Helper that returns the current collection timestamp.
@@ -147,4 +136,4 @@ INSERT INTO metadata (name, value) VALUES ('created_at', NOW()::TEXT);
 
 -- Set storage schema version.
 -- Should match ``cliquet.storage.postgresql.PostgreSQL.schema_version``
-INSERT INTO metadata (name, value) VALUES ('storage_schema_version', '4');
+INSERT INTO metadata (name, value) VALUES ('storage_schema_version', '5');

--- a/cliquet/storage/postgresql/schema.sql
+++ b/cliquet/storage/postgresql/schema.sql
@@ -8,13 +8,6 @@ END;
 $$ LANGUAGE plpgsql
 IMMUTABLE;
 
-CREATE OR REPLACE FUNCTION from_epoch(ts BIGINT) RETURNS TIMESTAMP AS $$
-BEGIN
-    RETURN to_timestamp(ts / 1000.0) AT TIME ZONE 'UTC';
-END;
-$$ LANGUAGE plpgsql
-IMMUTABLE;
-
 --
 -- Actual records
 --
@@ -37,6 +30,8 @@ CREATE TABLE IF NOT EXISTS records (
 DROP INDEX IF EXISTS idx_records_user_id_resource_name_last_modified;
 CREATE UNIQUE INDEX idx_records_user_id_resource_name_last_modified
     ON records(user_id, resource_name, last_modified DESC);
+DROP INDEX IF EXISTS idx_records_last_modified_epoch;
+CREATE INDEX idx_records_last_modified_epoch ON records(as_epoch(last_modified));
 
 
 --
@@ -53,6 +48,8 @@ CREATE TABLE IF NOT EXISTS deleted (
 DROP INDEX IF EXISTS idx_records_user_id_resource_name_last_modified;
 CREATE UNIQUE INDEX idx_records_user_id_resource_name_last_modified
     ON records(user_id, resource_name, last_modified DESC);
+DROP INDEX IF EXISTS idx_deleted_last_modified_epoch;
+CREATE INDEX idx_deleted_last_modified_epoch ON deleted(as_epoch(last_modified));
 
 
 --


### PR DESCRIPTION
Based on #208, review should be easier on last commit only.

------

Indices were not restricted to those used in queries. Indexing an individual column if it is not used in queries is a waste. This PR removes redundants indices and make sure queries target the existing indices on tuples (id, user_id, resource_name) and (user_id, resource_name, last_modified).

In addition to cleaner schema, it improves creation significantly (~35%):

*before*

    testdb=# INSERT INTO records(id, user_id, resource_name, data) SELECT uuid_generate_v4(), * FROM generate_records(100000, 1, 10);
    INSERT 0 1000000
    Time: 114463,644 ms

*after*

    INSERT INTO records(id, user_id, resource_name, data) SELECT uuid_generate_v4(), * FROM generate_records(100000, 1, 10);
    INSERT 0 1000000
    Time: 73150,822 ms