### PR TITLE
Fix migration behaviour when metadata table was flushed.

### DIFF
--- a/cliquet/storage/postgresql/__init__.py
+++ b/cliquet/storage/postgresql/__init__.py
@@ -222,7 +222,16 @@ class PostgreSQL(PostgreSQLClient, StorageBase):
             if cursor.rowcount > 0:
                 return int(cursor.fetchone()['version'])
             else:
-                # In the first versions of cliquet, there was no migration.
+                # Guess current version.
+                query = "SELECT COUNT(*) FROM metadata;"
+                cursor.execute(query)
+                was_flushed = int(cursor.fetchone()[0]) == 0
+                if was_flushed:
+                    error_msg = 'Missing schema history: consider version %s.'
+                    logger.warning(error_msg % self.schema_version)
+                    return self.schema_version
+
+                # In the first versions of Cliquet, there was no migration.
                 return 1
 
     def flush(self):

--- a/cliquet/tests/test_storage_migrations.py
+++ b/cliquet/tests/test_storage_migrations.py
@@ -114,3 +114,11 @@ class PostgresqlStorageMigrationTest(unittest.TestCase):
 
         migrated, count = self.db.get_all(TestResource(), 'jean-louis')
         self.assertEqual(migrated[0]['drink'], 'cacao')
+
+    def test_every_available_migration_succeeds_if_tables_were_flushed(self):
+        # During tests, tables can be flushed.
+        self.db.flush()
+        self.db.initialize_schema()
+        # Version matches current one.
+        version = self.db._get_installed_version()
+        self.assertEqual(version, self.version)


### PR DESCRIPTION
Reading List tests could not be run several times in a row because the metadata table was flushed, and migrations were failing while being applied on the last schema version.

We now consider the schema as the last version if metadata is empty.