### PR TITLE
In Python3 headers should be str and in Python2 they should be bytes.

### DIFF
--- a/cliquet/resource.py
+++ b/cliquet/resource.py
@@ -142,10 +142,12 @@ class BaseResource(object):
         records, total_records, next_page = self.get_records()
 
         headers = self.request.response.headers
-        headers['Total-Records'] = ('%s' % total_records).encode('utf-8')
+        headers['Total-Records'] = ('%s' % total_records)
 
         if next_page:
-            headers['Next-Page'] = next_page.encode('utf-8')
+            if next_page.__class__ is not str:
+                next_page = next_page.encode('utf-8')
+            headers['Next-Page'] = next_page
         body = {
             'items': records,
         }

--- a/cliquet/resource.py
+++ b/cliquet/resource.py
@@ -145,8 +145,6 @@ class BaseResource(object):
         headers['Total-Records'] = ('%s' % total_records)
 
         if next_page:
-            if not isinstance(next_page, str):
-                next_page = next_page.encode('utf-8')
             headers['Next-Page'] = next_page
         body = {
             'items': records,

--- a/cliquet/resource.py
+++ b/cliquet/resource.py
@@ -145,7 +145,7 @@ class BaseResource(object):
         headers['Total-Records'] = ('%s' % total_records)
 
         if next_page:
-            if next_page.__class__ is not str:
+            if not isinstance(next_page, str):
                 next_page = next_page.encode('utf-8')
             headers['Next-Page'] = next_page
         body = {

--- a/cliquet/tests/resource/test_pagination.py
+++ b/cliquet/tests/resource/test_pagination.py
@@ -1,8 +1,7 @@
-import mock
 import random
-import six
-
 from base64 import b64encode, b64decode
+
+import mock
 from six.moves.urllib.parse import parse_qs, urlparse
 from pyramid.httpexceptions import HTTPBadRequest
 
@@ -27,8 +26,6 @@ class PaginationTest(BaseTest):
 
     def _setup_next_page(self):
         next_page = self.last_response.headers['Next-Page']
-        if next_page.__class__ is not six.text_type:
-            next_page = next_page.decode('utf8')
         url_fragments = urlparse(next_page)
         queryparams = parse_qs(url_fragments.query)
         self.resource.request.GET['_token'] = queryparams['_token'][0]

--- a/cliquet/tests/resource/test_pagination.py
+++ b/cliquet/tests/resource/test_pagination.py
@@ -1,7 +1,8 @@
-import random
-from base64 import b64encode, b64decode
-
 import mock
+import random
+import six
+
+from base64 import b64encode, b64decode
 from six.moves.urllib.parse import parse_qs, urlparse
 from pyramid.httpexceptions import HTTPBadRequest
 
@@ -25,7 +26,9 @@ class PaginationTest(BaseTest):
             self.db.create(self.resource, 'bob', record)
 
     def _setup_next_page(self):
-        next_page = self.last_response.headers['Next-Page'].decode('utf-8')
+        next_page = self.last_response.headers['Next-Page']
+        if next_page.__class__ is not six.text_type:
+            next_page = next_page.decode('utf8')
         url_fragments = urlparse(next_page)
         queryparams = parse_qs(url_fragments.query)
         self.resource.request.GET['_token'] = queryparams['_token'][0]

--- a/cliquet/tests/resource/test_views.py
+++ b/cliquet/tests/resource/test_views.py
@@ -294,27 +294,23 @@ class PaginationNextURLTest(FakeAuthentMixin, BaseWebTest):
         resp = self.app.get(self.collection_url + '?_limit=1',
                             extra_environ={'HTTP_HOST': 'localhost:8000'},
                             headers=self.headers)
-        next_page = resp.headers['Next-Page'].decode('utf8')
-        self.assertIn(':8000', next_page)
+        self.assertIn(':8000', resp.headers['Next-Page'])
 
     def test_next_page_url_has_not_port_number_if_80(self):
         resp = self.app.get(self.collection_url + '?_limit=1',
                             extra_environ={'HTTP_HOST': 'localhost:80'},
                             headers=self.headers)
-        next_page = resp.headers['Next-Page'].decode('utf8')
-        self.assertNotIn(':80', next_page)
+        self.assertNotIn(':80', resp.headers['Next-Page'])
 
     def test_next_page_url_relies_on_pyramid_url_system(self):
         resp = self.app.get(self.collection_url + '?_limit=1',
                             extra_environ={'wsgi.url_scheme': 'https'},
                             headers=self.headers)
-        next_page = resp.headers['Next-Page'].decode('utf8')
-        self.assertIn('https://', next_page)
+        self.assertIn('https://', resp.headers['Next-Page'])
 
     def test_next_page_url_relies_on_headers_information(self):
         headers = self.headers.copy()
         headers['Host'] = 'https://server.name:443'
         resp = self.app.get(self.collection_url + '?_limit=1',
                             headers=headers)
-        next_page = resp.headers['Next-Page'].decode('utf8')
-        self.assertIn('https://server.name:443', next_page)
+        self.assertIn('https://server.name:443', resp.headers['Next-Page'])


### PR DESCRIPTION
Fixes mozilla-services/kinto#18