### PR TITLE
Fix regression of schema simplification

### DIFF
--- a/cliquet/resource.py
+++ b/cliquet/resource.py
@@ -113,7 +113,7 @@ class BaseResource(object):
 
         """
         known_fields = [c.name for c in self.mapping.children] + \
-                       [self.deleted_field]
+                       [self.id_field, self.modified_field, self.deleted_field]
         return field in known_fields
 
     #

--- a/cliquet/tests/resource/test_filter.py
+++ b/cliquet/tests/resource/test_filter.py
@@ -25,6 +25,13 @@ class FilteringTest(BaseTest):
         self.assertEqual(len(result['items']), 1)
         self.assertTrue(result['items'][0]['deleted'])
 
+    def test_filter_on_id_is_supported(self):
+        self.patch_known_field.stop()
+        r = self.db.create(self.resource, 'bob', {})
+        self.resource.request.GET = {'id': '%s' % r['id']}
+        result = self.resource.collection_get()
+        self.assertEqual(result['items'][0], r)
+
     def test_list_cannot_be_filtered_on_deleted_without_since(self):
         r = self.db.create(self.resource, 'bob', {})
         self.db.delete(self.resource, 'bob', r['id'])

--- a/cliquet/tests/resource/test_sort.py
+++ b/cliquet/tests/resource/test_sort.py
@@ -47,6 +47,13 @@ class SortingTest(BaseTest):
             'code': 400,
             'error': 'Invalid parameters'})
 
+    def test_sort_on_last_modified_is_supported(self):
+        self.patch_known_field.stop()
+        self.resource.request.GET = {'_sort': '-last_modified'}
+        result = self.resource.collection_get()
+        timestamp = self.db.collection_timestamp(self.resource, 'bob')
+        self.assertEqual(result['items'][0]['last_modified'], timestamp)
+
     def test_single_basic_sort_by_attribute(self):
         self.resource.request.GET = {'_sort': 'title'}
         result = self.resource.collection_get()


### PR DESCRIPTION
Since id and last_modified are not part of the schema,
they should be explicitly allowed for sorting and
filtering.

(*I was seeing 400 errors in RL load tests*)

@Natim r?