### PR TITLE
More realistic epoch milliseconds value in example

### DIFF
--- a/docs/api/resource.rst
+++ b/docs/api/resource.rst
@@ -134,7 +134,7 @@ Polling for changes
 
 The ``_since`` parameter is provided as an alias for ``gt_last_modified``.
 
-* ``/collection?_since=123456``
+* ``/collection?_since=1234567890123``
 
 When filtering on ``last_modified`` every deleted records will appear in the
 list with a deleted status (``deleted=true``).


### PR DESCRIPTION
This parameter should be given in milliseconds since 1970, probably? So this way it's maybe clearer (timestamp 1234567890.123 was in February 2009)