### PR TITLE
Remove unicode content from CONTRIBUTORS file.

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -2,8 +2,9 @@ Contributors
 ============
 
 * Alexis Metaireau <alexis@mozilla.com>
+* Michiel de Jong <michiel@unhosted.org>
 * hiromipaw <silvia@nopressure.co.uk>
 * Mathieu Leplatre <mathieu@mozilla.com>
 * Nicolas Perriault <nperriault@mozilla.com>
-* Remy Hubscher <rhubscher@mozilla.com>
+* Rémy Hubscher <rhubscher@mozilla.com>
 * Tarek Ziade <tarek@mozilla.com>

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -5,5 +5,5 @@ Contributors
 * hiromipaw <silvia@nopressure.co.uk>
 * Mathieu Leplatre <mathieu@mozilla.com>
 * Nicolas Perriault <nperriault@mozilla.com>
-* Rémy Hubscher <rhubscher@mozilla.com>
+* Remy Hubscher <rhubscher@mozilla.com>
 * Tarek Ziade <tarek@mozilla.com>

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,17 @@
+import codecs
 import os
 from setuptools import setup, find_packages
 
 here = os.path.abspath(os.path.dirname(__file__))
 
-with open(os.path.join(here, 'README.rst')) as f:
+with codecs.open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
     README = f.read()
 
-with open(os.path.join(here, 'CHANGELOG.rst')) as f:
+with codecs.open(os.path.join(here, 'CHANGELOG.rst'), encoding='utf-8') as f:
     CHANGELOG = f.read()
 
-with open(os.path.join(here, 'CONTRIBUTORS.rst')) as f:
+with codecs.open(os.path.join(here, 'CONTRIBUTORS.rst'),
+                 encoding='utf-8') as f:
     CONTRIBUTORS = f.read()
 
 


### PR DESCRIPTION
Tests fail with python3 because of this : 
https://travis-ci.org/mozilla-services/cliquet/jobs/62362839

In setup.py it should be read like this in python3:

    f = open('CONTRIBUTORS.txt', encoding='utf-8')

and in python 2:

    f = codecs.open('CONTRIBUTORS.txt', encoding='utf-8')

...so instead of introducing compat code in setup, just
remove utf8 from CONTRIBUTORS file.


@tarekziade r?