### PR TITLE
Crud decorator refactor (fixes #12)

### DIFF
--- a/cliquet/__init__.py
+++ b/cliquet/__init__.py
@@ -108,12 +108,6 @@ def includeme(config):
     load_default_settings(config, DEFAULT_SETTINGS)
     settings = config.get_settings()
 
-    # Monkey Patch Cornice Service to setup the global CORS configuration.
-    # XXX: Refactor @crud decorator and inherit Service instead.
-    cors_origins = settings['cliquet.cors_origins']
-    Service.cors_origins = tuple(aslist(cors_origins))
-    Service.default_cors_headers = ('Backoff', 'Retry-After', 'Alert')
-
     # Heartbeat registry.
     config.registry.heartbeats = {}
 

--- a/cliquet/__init__.py
+++ b/cliquet/__init__.py
@@ -4,7 +4,7 @@ import warnings
 import pkg_resources
 
 import structlog
-from cornice import Service
+from cornice import Service as CorniceService
 from pyramid.settings import asbool, aslist
 
 # Main Cliquet logger.
@@ -74,6 +74,14 @@ DEFAULT_SETTINGS = {
 }
 
 
+class Service(CorniceService):
+    """Subclass of the default cornice service.
+
+    This is useful in order to attach specific behaviours without monkey
+    patching the default cornice service (which would impact other uses of it)
+    """
+
+
 def load_default_settings(config, default_settings):
     """Read settings provided in Paste ini file, set default values and
     replace if defined as environment variable.
@@ -107,6 +115,11 @@ def load_default_settings(config, default_settings):
 def includeme(config):
     load_default_settings(config, DEFAULT_SETTINGS)
     settings = config.get_settings()
+
+    # Add CORS settings to the base cliquet Service class.
+    cors_origins = settings['cliquet.cors_origins']
+    Service.cors_origins = tuple(aslist(cors_origins))
+    Service.default_cors_headers = ('Backoff', 'Retry-After', 'Alert')
 
     # Heartbeat registry.
     config.registry.heartbeats = {}

--- a/cliquet/resource.py
+++ b/cliquet/resource.py
@@ -85,6 +85,10 @@ class ViewSet(object):
         if method.lower() in map(str.lower, self.validate_schema_for):
             args['schema'] = resource.mapping
 
+        permission = self.get_view_permission(typ_, resource, method)
+        if permission is not None:
+            args['permission'] = permission
+
         return args
 
     def get_view(self, typ_, method):

--- a/cliquet/resource.py
+++ b/cliquet/resource.py
@@ -105,8 +105,7 @@ class ViewSet(object):
         """
         if endpoint_type == 'record':
             return method.lower()
-        else:
-            return '%s_%s' % (endpoint_type, method.lower())
+        return '%s_%s' % (endpoint_type, method.lower())
 
     def get_name(self, resource):
         """Returns the name of the resource.

--- a/cliquet/resource.py
+++ b/cliquet/resource.py
@@ -23,6 +23,11 @@ from cliquet.utils import (
 
 
 class ViewSet(object):
+    """The default ViewSet object.
+
+    A viewset contains all the information needed to register
+    any resource in the  cornice registry.
+    """
     collection_path = "/{resource_name}s"
     record_path = "/{resource_name}s/{{id}}"
 
@@ -88,6 +93,12 @@ class ViewSet(object):
 
 
 def register(depth=1, **kwargs):
+    """Ressource class decorator.
+
+    Registers the decorated class in the cornice registry.
+    Passes all its keyword arguments to the register_resource
+    function.
+    """
     def wrapped(resource):
         register_resource(resource, depth=depth + 1, **kwargs)
         return resource
@@ -96,6 +107,27 @@ def register(depth=1, **kwargs):
 
 def register_resource(resource, settings=None, viewset=None, depth=1,
                       **kwargs):
+    """Register a resource in the cornice registry.
+
+    :param resource:
+        The resource class to register.
+        It should be a class or have a "name" attribute.
+
+    :param settings:
+        A dict of settings. It will be used to check if views aren't disabled
+        before registering them.
+
+    :param viewset:
+        A ViewSet object, which will be used to find out which arguments should
+        be appended to the views, and where the views are.
+
+    :param depth:
+        A depth offset. It will be used to determine what is the level of depth
+        in the call tree. (set to 1 by default.)
+
+    Any additional keyword parameters will be used to override the viewset
+    attributes.
+    """
     # config.add_directive('register') ?
     if settings is None:
         settings = {}

--- a/cliquet/resource.py
+++ b/cliquet/resource.py
@@ -35,6 +35,8 @@ class ViewSet(object):
     record_methods = ('GET', 'PUT', 'PATCH', 'DELETE')
     validate_schema_for = ('POST', 'PUT')
 
+    readonly_methods = ('GET',)
+
     service_arguments = {
         'description': 'Collection of {resource_name}',
         'cors_origins': ('*',),
@@ -115,6 +117,14 @@ class ViewSet(object):
         name = self.get_name(resource)
         return '-'.join((name, typ_))
 
+    def get_view_permission(self, typ_, resource, method):
+        """Returns the permission associated with the given type,
+        resource and method"""
+        if method.lower() in map(str.lower, self.readonly_methods):
+            permission = "readonly"
+        else:
+            permission = "readwrite"
+        return permission
 
 
 def register(depth=1, **kwargs):

--- a/cliquet/resource.py
+++ b/cliquet/resource.py
@@ -85,6 +85,9 @@ class ViewSet(object):
 
         if method.lower() in map(str.lower, self.validate_schema_for):
             args['schema'] = resource.mapping
+        else:
+            # Simply validate that posted body is a mapping.
+            args['schema'] = colander.MappingSchema(unknown='preserve')
 
         permission = self.get_view_permission(typ_, resource, method)
         if permission is not None:

--- a/cliquet/resource.py
+++ b/cliquet/resource.py
@@ -30,20 +30,23 @@ class ViewSet(object):
     record_methods = ('GET', 'PUT', 'PATCH', 'DELETE')
     validate_schema_for = ('POST', 'PUT')
 
-    default_arguments = {
-        'cors_headers': ('Backoff', 'Retry-After', 'Alert'),
-    }
-
     service_arguments = {
         'description': 'Collection of {resource_name}',
         'cors_origins': ('*',),
         'error_handler': json_error_handler
     }
+
+    default_arguments = {
+        'cors_headers': ('Backoff', 'Retry-After', 'Alert'),
+    }
+
+
     default_collection_arguments = {}
     collection_get_arguments = {
         'cors_headers': (('Backoff', 'Retry-After', 'Alert') +
                         ('Next-Page', 'Total-Records', 'Last-Modified'))
     }
+
     default_record_arguments = {}
     record_get_arguments = {
         'cors_headers': (('Backoff', 'Retry-After', 'Alert') +

--- a/cliquet/resource.py
+++ b/cliquet/resource.py
@@ -65,14 +65,14 @@ class ViewSet(object):
     def __init__(self, **kwargs):
         self.update(**kwargs)
         self.record_arguments = functools.partial(
-                                        self.get_arguments, 'record')
+                                        self.get_view_args, 'record')
         self.collection_arguments = functools.partial(
-                                        self.get_arguments, 'collection')
+                                        self.get_view_args, 'collection')
 
     def update(self, **kwargs):
         self.__dict__.update(**kwargs)
 
-    def get_arguments(self, endpoint_type, resource, method):
+    def get_view_args(self, endpoint_type, resource, method):
         """Returns the arguments for the given type, where `endpoint_type` can
         be either "collection" or "record".
         """
@@ -207,7 +207,6 @@ def register_resource(resource, settings=None, viewset=None, depth=1,
             if not settings.get(setting_enabled, True):
                 continue
 
-            # XXX use viewset.get_arguments() directly ?
             argument_getter = getattr(viewset, '%s_arguments' % endpoint_type)
             view_args = argument_getter(resource, method)
 

--- a/cliquet/resource.py
+++ b/cliquet/resource.py
@@ -49,25 +49,24 @@ class ViewSet(object):
         'cors_headers': ('Backoff', 'Retry-After', 'Alert'),
     }
 
-
     default_collection_arguments = {}
     collection_get_arguments = {
         'cors_headers': (('Backoff', 'Retry-After', 'Alert') +
-                        ('Next-Page', 'Total-Records', 'Last-Modified'))
+                         ('Next-Page', 'Total-Records', 'Last-Modified'))
     }
 
     default_record_arguments = {}
     record_get_arguments = {
         'cors_headers': (('Backoff', 'Retry-After', 'Alert') +
-                        ('Last-Modified',))
+                         ('Last-Modified',))
     }
 
     def __init__(self, **kwargs):
         self.update(**kwargs)
         self.record_arguments = functools.partial(
-                                        self.get_view_args, 'record')
+            self.get_view_args, 'record')
         self.collection_arguments = functools.partial(
-                                        self.get_view_args, 'collection')
+            self.get_view_args, 'collection')
 
     def update(self, **kwargs):
         self.__dict__.update(**kwargs)
@@ -228,7 +227,6 @@ def register_resource(resource, settings=None, viewset=None, depth=1,
     info = venusian.attach(resource, callback, category='pyramid',
                            depth=depth)
     return services
-
 
 
 class BaseResource(object):

--- a/cliquet/resource.py
+++ b/cliquet/resource.py
@@ -178,7 +178,8 @@ def register_resource(resource, settings=None, viewset=None, depth=1,
         path = getattr(viewset, '%s_path' % typ_).format(**path_formatters)
 
         name = viewset.get_service_name(typ_, resource)
-        service = Service(name, path, depth=depth)
+        service = Service(name, path, depth=depth,
+                          **viewset.service_arguments or {})
 
         methods = getattr(viewset, '%s_methods' % typ_)
         for method in methods:

--- a/cliquet/resource.py
+++ b/cliquet/resource.py
@@ -29,6 +29,7 @@ class ViewSet(object):
     A viewset contains all the information needed to register
     any resource in the  cornice registry.
     """
+    service_name = "{resource_name}-{endpoint_type}"
     collection_path = "/{resource_name}s"
     record_path = "/{resource_name}s/{{id}}"
 
@@ -122,8 +123,9 @@ class ViewSet(object):
         """Returns the name of the service, depending a given type and
         resource.
         """
-        name = self.get_name(resource)
-        return '-'.join((name, typ_))
+        return self.service_name.format(
+            resource_name=self.get_name(resource),
+            endpoint_type=typ_)
 
     def get_view_permission(self, typ_, resource, method):
         """Returns the permission associated with the given type,

--- a/cliquet/resource.py
+++ b/cliquet/resource.py
@@ -3,7 +3,7 @@ import functools
 
 import colander
 import venusian
-from cornice import resource, Service
+from cornice import resource
 from cornice.schemas import CorniceSchema
 from pyramid.httpexceptions import (HTTPNotModified, HTTPPreconditionFailed,
                                     HTTPMethodNotAllowed,
@@ -11,6 +11,7 @@ from pyramid.httpexceptions import (HTTPNotModified, HTTPPreconditionFailed,
 import six
 
 from cliquet import logger
+from cliquet import Service
 from cliquet.collection import Collection
 from cliquet.errors import (http_error, raise_invalid, ERRORS,
                             json_error_handler)
@@ -171,11 +172,6 @@ def register_resource(resource, settings=None, viewset=None, depth=1,
     if settings is None:
         settings = {}
 
-    #cors_origins = tuple(aslist(settings['cliquet.cors_origins']))
-    # cors_policy = {
-    #     'origins': ('*',),
-    # }
-
     if viewset is None:
         viewset = ViewSet(**kwargs)
     else:
@@ -192,6 +188,7 @@ def register_resource(resource, settings=None, viewset=None, depth=1,
         path = getattr(viewset, '%s_path' % typ_).format(**path_formatters)
 
         name = viewset.get_service_name(typ_, resource)
+
         service = Service(name, path, depth=depth,
                           **viewset.service_arguments or {})
 

--- a/cliquet/tests/test_resource.py
+++ b/cliquet/tests/test_resource.py
@@ -29,12 +29,12 @@ class FakeResource(object):
     def __init__(self):
         # Create fake views which are in fact mock sentinels.
         # {type}_{method} will map to the sentinel with the same name.
-        for typ_ in ('collection', 'record'):
+        for endpoint_type in ('collection', 'record'):
             for method in ('get', 'put', 'patch', 'delete'):
-                if typ_ == 'record':
+                if endpoint_type == 'record':
                     view_name = method
                 else:
-                    view_name = '_'.join((typ_, method))
+                    view_name = '_'.join((endpoint_type, method))
                 setattr(self, view_name, getattr(sentinel, view_name))
 
 

--- a/cliquet/tests/test_resource.py
+++ b/cliquet/tests/test_resource.py
@@ -82,6 +82,18 @@ class ViewSetTest(unittest.TestCase):
         patched.from_colander.assert_not_called()
         self.assertNotIn('schema', arguments)
 
+    def test_permission_is_added_when_needed(self):
+        viewset = ViewSet(readonly_methods=('GET',))
+        arguments = viewset.collection_arguments(MagicMock(), 'GET')
+        self.assertIn('permission', arguments)
+        self.assertEquals(arguments['permission'], 'readonly')
+
+    def test_permission_is_ignored_when_not_needed(self):
+        viewset = ViewSet(readonly_methods=())
+        viewset.get_view_permission = lambda *args: None
+        arguments = viewset.collection_arguments(MagicMock(), 'GET')
+        self.assertNotIn('permission', arguments)
+
     def test_class_parameters_are_used_for_collection_arguments(self):
         default_arguments = {
             'cors_headers': sentinel.cors_headers,
@@ -106,7 +118,8 @@ class ViewSetTest(unittest.TestCase):
             {
                 'cors_headers': sentinel.cors_headers,
                 'cors_origins': sentinel.cors_origins,
-                'error_handler': sentinel.error_handler
+                'error_handler': sentinel.error_handler,
+                'permission': 'readonly'
             }
         )
 
@@ -134,7 +147,8 @@ class ViewSetTest(unittest.TestCase):
             {
                 'cors_headers': sentinel.cors_headers,
                 'cors_origins': sentinel.record_cors_origins,
-                'error_handler': sentinel.error_handler
+                'error_handler': sentinel.error_handler,
+                'permission': 'readonly'
             }
         )
 
@@ -169,6 +183,7 @@ class ViewSetTest(unittest.TestCase):
                 'cors_headers': sentinel.default_cors_headers,
                 'error_handler': sentinel.default_record_error_handler,
                 'cors_origins': sentinel.record_get_cors_origin,
+                'permission': 'readonly'
             }
         )
 
@@ -194,6 +209,7 @@ class ViewSetTest(unittest.TestCase):
             arguments,
             {
                 'cors_headers': sentinel.cors_headers,
+                'permission': 'readonly'
             }
         )
 

--- a/cliquet/tests/test_resource.py
+++ b/cliquet/tests/test_resource.py
@@ -4,6 +4,7 @@ from cliquet.resource import ViewSet, register_resource
 
 from .support import unittest
 
+
 class FakeViewSet(ViewSet):
     """Fake viewset class used for tests."""
     collection_path = "/{resource_name}"
@@ -75,8 +76,8 @@ class ViewSetTest(unittest.TestCase):
 
     @mock.patch('cliquet.resource.colander')
     @mock.patch('cliquet.resource.CorniceSchema')
-    def test_a_default_schema_is_added_when_method_doesnt_match(self,
-            cornice_schema, colander):
+    def test_a_default_schema_is_added_when_method_doesnt_match(
+            self, cornice_schema, colander):
         viewset = ViewSet(
             validate_schema_for=('GET', )
         )
@@ -198,7 +199,6 @@ class ViewSetTest(unittest.TestCase):
             'cors_headers': mock.sentinel.cors_headers,
         }
 
-
         viewset = ViewSet(
             default_arguments=default_arguments,
             service_arguments=service_arguments,
@@ -276,7 +276,8 @@ class RegisterTest(unittest.TestCase):
     @mock.patch('cliquet.resource.Service')
     def test_viewset_is_updated_if_provided(self, service_class):
         additional_params = {'foo': 'bar'}
-        register_resource(self.resource, viewset=self.viewset, **additional_params)
+        register_resource(self.resource, viewset=self.viewset,
+                          **additional_params)
         self.viewset.update.assert_called_with(**additional_params)
 
     @mock.patch('cliquet.resource.Service')
@@ -297,7 +298,6 @@ class RegisterTest(unittest.TestCase):
         service_class().add_view.assert_any_call(
             'PUT', 'put', klass=self.resource)
 
-
     @mock.patch('cliquet.resource.Service')
     def test_record_methods_are_skipped_if_not_enabled(self, service_class):
         register_resource(self.resource, viewset=self.viewset, settings={
@@ -313,7 +313,6 @@ class RegisterTest(unittest.TestCase):
         service_class().add_view.assert_any_call(
             'GET', 'collection_get', klass=self.resource)
 
-
     @mock.patch('cliquet.resource.Service')
     def test_record_methods_are_skipped_if_not_enabled(self, service_class):
         register_resource(self.resource, viewset=self.viewset, settings={
@@ -328,4 +327,3 @@ class RegisterTest(unittest.TestCase):
                                       **self.viewset.service_arguments)
         service_class().add_view.assert_any_call(
             'PUT', 'put', klass=self.resource)
-

--- a/cliquet/tests/test_resource.py
+++ b/cliquet/tests/test_resource.py
@@ -237,7 +237,8 @@ class RegisterTest(unittest.TestCase):
     def test_collection_views_are_registered_in_cornice(self, service_class):
         register_resource(self.resource, viewset=self.viewset)
 
-        service_class.assert_any_call('fake-collection', '/fake', depth=1)
+        service_class.assert_any_call('fake-collection', '/fake', depth=1,
+                                      **self.viewset.service_arguments)
         service_class().add_view.assert_any_call(
             'GET', 'collection_get', klass=self.resource)
 
@@ -245,7 +246,8 @@ class RegisterTest(unittest.TestCase):
     def test_record_views_are_registered_in_cornice(self, service_class):
         register_resource(self.resource, viewset=self.viewset)
 
-        service_class.assert_any_call('fake-record', '/fake/{id}', depth=1)
+        service_class.assert_any_call('fake-record', '/fake/{id}', depth=1,
+                                      **self.viewset.service_arguments)
         service_class().add_view.assert_any_call(
             'PUT', 'put', klass=self.resource)
 
@@ -260,7 +262,8 @@ class RegisterTest(unittest.TestCase):
         # 3 calls: two registering the service classes,
         # one for the collection_get
         self.assertEquals(len(service_class.mock_calls), 3)
-        service_class.assert_any_call('fake-collection', '/fake', depth=1)
+        service_class.assert_any_call('fake-collection', '/fake', depth=1,
+                                      **self.viewset.service_arguments)
         service_class().add_view.assert_any_call(
             'GET', 'collection_get', klass=self.resource)
 
@@ -275,7 +278,8 @@ class RegisterTest(unittest.TestCase):
         # 3 calls: two registering the service classes,
         # one for the collection_get
         self.assertEquals(len(service_class.mock_calls), 3)
-        service_class.assert_any_call('fake-record', '/fake/{id}', depth=1)
+        service_class.assert_any_call('fake-record', '/fake/{id}', depth=1,
+                                      **self.viewset.service_arguments)
         service_class().add_view.assert_any_call(
             'PUT', 'put', klass=self.resource)
 

--- a/cliquet/tests/test_resource.py
+++ b/cliquet/tests/test_resource.py
@@ -192,7 +192,7 @@ class RegisterTest(unittest.TestCase):
     def test_collection_views_are_registered_in_cornice(self, service_class):
         register(self.resource, viewset=self.viewset)
 
-        service_class.assert_any_call(self.resource.name, '/fake')
+        service_class.assert_any_call('fake-collection', '/fake')
         service_class().add_view.assert_any_call(
             'GET', sentinel.collection_get)
 
@@ -200,7 +200,7 @@ class RegisterTest(unittest.TestCase):
     def test_record_views_are_registered_in_cornice(self, service_class):
         register(self.resource, viewset=self.viewset)
 
-        service_class.assert_any_call(self.resource.name, '/fake/{id}')
+        service_class.assert_any_call('fake-record', '/fake/{id}')
         service_class().add_view.assert_any_call(
             'PUT', sentinel.record_put)
 
@@ -215,7 +215,7 @@ class RegisterTest(unittest.TestCase):
         # 3 calls: two registering the service classes,
         # one for the collection_get
         self.assertEquals(len(service_class.mock_calls), 3)
-        service_class.assert_any_call(self.resource.name, '/fake')
+        service_class.assert_any_call('fake-collection', '/fake')
         service_class().add_view.assert_any_call(
             'GET', sentinel.collection_get)
 
@@ -230,7 +230,7 @@ class RegisterTest(unittest.TestCase):
         # 3 calls: two registering the service classes,
         # one for the collection_get
         self.assertEquals(len(service_class.mock_calls), 3)
-        service_class.assert_any_call(self.resource.name, '/fake/{id}')
+        service_class.assert_any_call('fake-record', '/fake/{id}')
         service_class().add_view.assert_any_call(
             'PUT', sentinel.record_put)
 

--- a/cliquet/tests/test_resource.py
+++ b/cliquet/tests/test_resource.py
@@ -220,6 +220,18 @@ class ViewSetTest(unittest.TestCase):
             viewset.get_service_name('record', resource),
             'fakename-record')
 
+    def test_get_view_permission_returns_readwrite_by_default(self):
+        viewset = ViewSet(readonly_methods=())
+        permission = viewset.get_view_permission("collection", MagicMock,
+                                                 "get")
+        self.assertEquals(permission, "readwrite")
+
+    def test_get_view_permissions_can_return_readonly(self):
+        viewset = ViewSet(readonly_methods=('GET',))
+        permission = viewset.get_view_permission("collection", MagicMock,
+                                                 "get")
+        self.assertEquals(permission, "readonly")
+
 
 class RegisterTest(unittest.TestCase):
 

--- a/cliquet/tests/test_resource.py
+++ b/cliquet/tests/test_resource.py
@@ -197,6 +197,28 @@ class ViewSetTest(unittest.TestCase):
             }
         )
 
+    def test_get_service_name_returns_the_viewset_name_if_defined(self):
+        viewset = ViewSet(name='fakename')
+        self.assertEquals(
+            viewset.get_service_name('record', MagicMock),
+            'fakename-record')
+
+    def test_get_service_name_returns_resource_att_if_not_callable(self):
+        viewset = ViewSet()
+        resource = MagicMock()
+        resource.name = 'fakename'
+        self.assertEquals(
+            viewset.get_service_name('record', resource),
+            'fakename-record')
+
+    def test_get_service_name_doesnt_use_callable_as_a_name(self):
+        viewset = ViewSet()
+        resource = MagicMock()
+        resource.name = lambda x: 'should not be called'
+        resource.__name__ = "FakeName"
+        self.assertEquals(
+            viewset.get_service_name('record', resource),
+            'fakename-record')
 
 
 class RegisterTest(unittest.TestCase):

--- a/cliquet/tests/test_resource.py
+++ b/cliquet/tests/test_resource.py
@@ -1,4 +1,4 @@
-from mock import sentinel, MagicMock, patch
+import mock
 
 from cliquet.resource import ViewSet, register_resource
 
@@ -15,7 +15,7 @@ class FakeViewSet(ViewSet):
     def __init__(self):
         self.collection_arguments = self.arguments
         self.record_arguments = self.arguments
-        self.update = MagicMock()
+        self.update = mock.MagicMock()
 
     def arguments(self, resource, method):
         # By default, returns an empty dict of arguments.
@@ -35,15 +35,15 @@ class FakeResource(object):
                     view_name = method
                 else:
                     view_name = '_'.join((endpoint_type, method))
-                setattr(self, view_name, getattr(sentinel, view_name))
+                setattr(self, view_name, getattr(mock.sentinel, view_name))
 
 
 class ViewSetTest(unittest.TestCase):
 
     def test_arguments_are_merged_on_initialization(self):
-        viewset = ViewSet(collection_path=sentinel.collection_path)
+        viewset = ViewSet(collection_path=mock.sentinel.collection_path)
         self.assertEquals(viewset.collection_path,
-                          sentinel.collection_path)
+                          mock.sentinel.collection_path)
 
     def test_default_arguments_are_copied_before_being_returned(self):
         original_arguments = {}
@@ -51,67 +51,56 @@ class ViewSetTest(unittest.TestCase):
             collection_get_arguments=original_arguments,
             validate_schema_for=()
         )
-        arguments = viewset.collection_arguments(sentinel.resource, 'GET')
+        arguments = viewset.collection_arguments(mock.sentinel.resource, 'GET')
         self.assertEquals(original_arguments, {})
+        self.assertNotEquals(original_arguments, arguments)
 
-    @patch('cliquet.resource.CorniceSchema')
+    @mock.patch('cliquet.resource.CorniceSchema')
     def test_schema_is_added_when_method_matches(self, patched):
         viewset = ViewSet(
             validate_schema_for=('GET', )
         )
-        resource = MagicMock()
+        resource = mock.MagicMock()
         arguments = viewset.collection_arguments(resource, 'GET')
         self.assertEquals(arguments['schema'], resource.mapping)
 
-    @patch('cliquet.resource.CorniceSchema')
-    def test_schema_is_added_when_method_is_uppercase(self, patched):
+    @mock.patch('cliquet.resource.CorniceSchema')
+    def test_schema_is_added_when_uppercase_method_matches(self, patched):
         viewset = ViewSet(
             validate_schema_for=('GET', )
         )
-        resource = MagicMock()
+        resource = mock.MagicMock()
         arguments = viewset.collection_arguments(resource, 'get')
         self.assertEquals(arguments['schema'], resource.mapping)
 
-    @patch('cliquet.resource.colander')
-    @patch('cliquet.resource.CorniceSchema')
+    @mock.patch('cliquet.resource.colander')
+    @mock.patch('cliquet.resource.CorniceSchema')
     def test_a_default_schema_is_added_when_method_doesnt_match(self,
             cornice_schema, colander):
         viewset = ViewSet(
             validate_schema_for=('GET', )
         )
-        resource = MagicMock()
-        colander.MappingSchema.return_value = sentinel.default_schema
+        resource = mock.MagicMock()
+        colander.MappingSchema.return_value = mock.sentinel.default_schema
 
         arguments = viewset.collection_arguments(resource, 'POST')
-        self.assertEquals(arguments['schema'], sentinel.default_schema)
+        self.assertEquals(arguments['schema'], mock.sentinel.default_schema)
 
         cornice_schema.from_colander.assert_not_called()
         self.assertNotEqual(arguments['schema'], resource.mapping)
 
         colander.MappingSchema.assert_called_with(unknown='preserve')
 
-    def test_permission_is_added_when_needed(self):
-        viewset = ViewSet(readonly_methods=('GET',))
-        arguments = viewset.collection_arguments(MagicMock(), 'GET')
-        self.assertIn('permission', arguments)
-        self.assertEquals(arguments['permission'], 'readonly')
-
-    def test_permission_is_ignored_when_not_needed(self):
-        viewset = ViewSet(readonly_methods=())
-        viewset.get_view_permission = lambda *args: None
-        arguments = viewset.collection_arguments(MagicMock(), 'GET')
-        self.assertNotIn('permission', arguments)
-
     def test_class_parameters_are_used_for_collection_arguments(self):
         default_arguments = {
-            'cors_headers': sentinel.cors_headers,
+            'cors_headers': mock.sentinel.cors_headers,
         }
         default_collection_arguments = {
-            'cors_origins': sentinel.cors_origins,
+            'cors_origins': mock.sentinel.cors_origins,
         }
 
         collection_get_arguments = {
-            'error_handler': sentinel.error_handler
+            'error_handler': mock.sentinel.error_handler
         }
 
         viewset = ViewSet(
@@ -120,28 +109,28 @@ class ViewSetTest(unittest.TestCase):
             collection_get_arguments=collection_get_arguments
         )
 
-        arguments = viewset.collection_arguments(MagicMock, 'get')
+        arguments = viewset.collection_arguments(mock.MagicMock, 'get')
         schema = arguments.pop('schema')
         self.assertDictEqual(
             arguments,
             {
-                'cors_headers': sentinel.cors_headers,
-                'cors_origins': sentinel.cors_origins,
-                'error_handler': sentinel.error_handler,
+                'cors_headers': mock.sentinel.cors_headers,
+                'cors_origins': mock.sentinel.cors_origins,
+                'error_handler': mock.sentinel.error_handler,
                 'permission': 'readonly'
             }
         )
 
     def test_default_arguments_are_used_for_record_arguments(self):
         default_arguments = {
-            'cors_headers': sentinel.cors_headers,
+            'cors_headers': mock.sentinel.cors_headers,
         }
         default_record_arguments = {
-            'cors_origins': sentinel.record_cors_origins,
+            'cors_origins': mock.sentinel.record_cors_origins,
         }
 
         record_get_arguments = {
-            'error_handler': sentinel.error_handler
+            'error_handler': mock.sentinel.error_handler
         }
 
         viewset = ViewSet(
@@ -150,15 +139,15 @@ class ViewSetTest(unittest.TestCase):
             record_get_arguments=record_get_arguments
         )
 
-        arguments = viewset.record_arguments(MagicMock, 'get')
+        arguments = viewset.record_arguments(mock.MagicMock, 'get')
         schema = arguments.pop('schema')
 
         self.assertDictEqual(
             arguments,
             {
-                'cors_headers': sentinel.cors_headers,
-                'cors_origins': sentinel.record_cors_origins,
-                'error_handler': sentinel.error_handler,
+                'cors_headers': mock.sentinel.cors_headers,
+                'cors_origins': mock.sentinel.record_cors_origins,
+                'error_handler': mock.sentinel.error_handler,
                 'permission': 'readonly'
             }
         )
@@ -168,17 +157,17 @@ class ViewSetTest(unittest.TestCase):
         # The more specifics should prevail over the more generics.
         # Items annoted with a "<<" are the one that should prevail.
         default_arguments = {
-            'cors_origins': sentinel.default_cors_origins,
-            'error_handler': sentinel.default_error_handler,
-            'cors_headers': sentinel.default_cors_headers,  # <<
+            'cors_origins': mock.sentinel.default_cors_origins,
+            'error_handler': mock.sentinel.default_error_handler,
+            'cors_headers': mock.sentinel.default_cors_headers,  # <<
         }
         default_record_arguments = {
-            'cors_origins': sentinel.default_record_cors_origin,
-            'error_handler': sentinel.default_record_error_handler,  # <<
+            'cors_origins': mock.sentinel.default_record_cors_origin,
+            'error_handler': mock.sentinel.default_record_error_handler,  # <<
         }
 
         record_get_arguments = {
-            'cors_origins': sentinel.record_get_cors_origin,  # <<
+            'cors_origins': mock.sentinel.record_get_cors_origin,  # <<
         }
 
         viewset = ViewSet(
@@ -187,15 +176,15 @@ class ViewSetTest(unittest.TestCase):
             record_get_arguments=record_get_arguments,
         )
 
-        arguments = viewset.record_arguments(MagicMock, 'get')
+        arguments = viewset.record_arguments(mock.MagicMock, 'get')
         schema = arguments.pop('schema')
 
         self.assertDictEqual(
             arguments,
             {
-                'cors_headers': sentinel.default_cors_headers,
-                'error_handler': sentinel.default_record_error_handler,
-                'cors_origins': sentinel.record_get_cors_origin,
+                'cors_headers': mock.sentinel.default_cors_headers,
+                'error_handler': mock.sentinel.default_record_error_handler,
+                'cors_origins': mock.sentinel.record_get_cors_origin,
                 'permission': 'readonly'
             }
         )
@@ -206,7 +195,7 @@ class ViewSetTest(unittest.TestCase):
         }
 
         default_arguments = {
-            'cors_headers': sentinel.cors_headers,
+            'cors_headers': mock.sentinel.cors_headers,
         }
 
 
@@ -217,12 +206,12 @@ class ViewSetTest(unittest.TestCase):
             record_get_arguments={}
         )
 
-        arguments = viewset.record_arguments(MagicMock, 'get')
+        arguments = viewset.record_arguments(mock.MagicMock, 'get')
         schema = arguments.pop('schema')
         self.assertDictEqual(
             arguments,
             {
-                'cors_headers': sentinel.cors_headers,
+                'cors_headers': mock.sentinel.cors_headers,
                 'permission': 'readonly',
             }
         )
@@ -230,12 +219,12 @@ class ViewSetTest(unittest.TestCase):
     def test_get_service_name_returns_the_viewset_name_if_defined(self):
         viewset = ViewSet(name='fakename')
         self.assertEquals(
-            viewset.get_service_name('record', MagicMock),
+            viewset.get_service_name('record', mock.MagicMock),
             'fakename-record')
 
     def test_get_service_name_returns_resource_att_if_not_callable(self):
         viewset = ViewSet()
-        resource = MagicMock()
+        resource = mock.MagicMock()
         resource.name = 'fakename'
         self.assertEquals(
             viewset.get_service_name('record', resource),
@@ -243,24 +232,39 @@ class ViewSetTest(unittest.TestCase):
 
     def test_get_service_name_doesnt_use_callable_as_a_name(self):
         viewset = ViewSet()
-        resource = MagicMock()
+        resource = mock.MagicMock()
         resource.name = lambda x: 'should not be called'
         resource.__name__ = "FakeName"
         self.assertEquals(
             viewset.get_service_name('record', resource),
             'fakename-record')
 
+
+class ViewPermissionTest(unittest.TestCase):
+
     def test_get_view_permission_returns_readwrite_by_default(self):
         viewset = ViewSet(readonly_methods=())
-        permission = viewset.get_view_permission("collection", MagicMock,
+        permission = viewset.get_view_permission("collection", mock.MagicMock,
                                                  "get")
         self.assertEquals(permission, "readwrite")
 
     def test_get_view_permissions_can_return_readonly(self):
         viewset = ViewSet(readonly_methods=('GET',))
-        permission = viewset.get_view_permission("collection", MagicMock,
+        permission = viewset.get_view_permission("collection", mock.MagicMock,
                                                  "get")
         self.assertEquals(permission, "readonly")
+
+    def test_permission_is_added_when_needed(self):
+        viewset = ViewSet(readonly_methods=('GET',))
+        arguments = viewset.collection_arguments(mock.MagicMock(), 'GET')
+        self.assertIn('permission', arguments)
+        self.assertEquals(arguments['permission'], 'readonly')
+
+    def test_permission_is_ignored_when_not_needed(self):
+        viewset = ViewSet(readonly_methods=())
+        viewset.get_view_permission = lambda *args: None
+        arguments = viewset.collection_arguments(mock.MagicMock(), 'GET')
+        self.assertNotIn('permission', arguments)
 
 
 class RegisterTest(unittest.TestCase):
@@ -269,13 +273,13 @@ class RegisterTest(unittest.TestCase):
         self.resource = FakeResource
         self.viewset = FakeViewSet()
 
-    @patch('cliquet.resource.Service')
+    @mock.patch('cliquet.resource.Service')
     def test_viewset_is_updated_if_provided(self, service_class):
         additional_params = {'foo': 'bar'}
         register_resource(self.resource, viewset=self.viewset, **additional_params)
         self.viewset.update.assert_called_with(**additional_params)
 
-    @patch('cliquet.resource.Service')
+    @mock.patch('cliquet.resource.Service')
     def test_collection_views_are_registered_in_cornice(self, service_class):
         register_resource(self.resource, viewset=self.viewset)
 
@@ -284,7 +288,7 @@ class RegisterTest(unittest.TestCase):
         service_class().add_view.assert_any_call(
             'GET', 'collection_get', klass=self.resource)
 
-    @patch('cliquet.resource.Service')
+    @mock.patch('cliquet.resource.Service')
     def test_record_views_are_registered_in_cornice(self, service_class):
         register_resource(self.resource, viewset=self.viewset)
 
@@ -294,7 +298,7 @@ class RegisterTest(unittest.TestCase):
             'PUT', 'put', klass=self.resource)
 
 
-    @patch('cliquet.resource.Service')
+    @mock.patch('cliquet.resource.Service')
     def test_record_methods_are_skipped_if_not_enabled(self, service_class):
         register_resource(self.resource, viewset=self.viewset, settings={
             'cliquet.record_fake_put_enabled': False
@@ -310,7 +314,7 @@ class RegisterTest(unittest.TestCase):
             'GET', 'collection_get', klass=self.resource)
 
 
-    @patch('cliquet.resource.Service')
+    @mock.patch('cliquet.resource.Service')
     def test_record_methods_are_skipped_if_not_enabled(self, service_class):
         register_resource(self.resource, viewset=self.viewset, settings={
             'cliquet.collection_fake_get_enabled': False

--- a/cliquet/tests/test_resource.py
+++ b/cliquet/tests/test_resource.py
@@ -1,0 +1,236 @@
+from mock import sentinel, MagicMock, patch
+
+from cliquet.resource import ViewSet, register
+
+from .support import unittest
+
+class FakeViewSet(object):
+    """Fake viewset class used for tests."""
+    collection_path = "/{resource_name}"
+    record_path = "/{resource_name}/{{id}}"
+
+    collection_methods = ('GET',)
+    record_methods = ('PUT',)
+
+    def __init__(self):
+        self.collection_arguments = self.arguments
+        self.record_arguments = self.arguments
+        self.update = MagicMock()
+
+    def arguments(self, resource, method):
+        # By default, returns an empty dict of arguments.
+        return {}
+
+
+class FakeResource(object):
+    """Fake resource class used for tests"""
+    name = "fake"
+
+    def __init__(self):
+        # Create fake views which are in fact mock sentinels.
+        # {type}_{method} will map to the sentinel with the same name.
+        for typ_ in ('collection', 'record'):
+            for method in ('get', 'put', 'patch', 'delete'):
+                view_name = '_'.join((typ_, method))
+                setattr(self, view_name, getattr(sentinel, view_name))
+
+
+class ViewSetTest(unittest.TestCase):
+
+    def test_arguments_are_merged_on_initialization(self):
+        viewset = ViewSet(collection_path=sentinel.collection_path)
+        self.assertEquals(viewset.collection_path,
+                          sentinel.collection_path)
+
+    def test_default_arguments_are_copied_before_being_returned(self):
+        original_arguments = {}
+        viewset = ViewSet(
+            collection_get_arguments=original_arguments,
+            validate_schema_for=()
+        )
+        arguments = viewset.collection_arguments(sentinel.resource, 'GET')
+        self.assertEquals(original_arguments, {})
+
+    @patch('cliquet.resource.CorniceSchema')
+    def test_schema_is_added_when_method_matches(self, patched):
+        viewset = ViewSet(
+            validate_schema_for=('GET', )
+        )
+        resource = MagicMock()
+        patched.from_colander.return_value = sentinel.schema
+        arguments = viewset.collection_arguments(resource, 'GET')
+        patched.from_colander.assert_called_with(resource.mapping,
+                                                 bind_request=False)
+        self.assertEquals(arguments['schema'], sentinel.schema)
+
+    @patch('cliquet.resource.CorniceSchema')
+    def test_schema_is_added_when_case_doesnt_match(self, patched):
+        viewset = ViewSet(
+            validate_schema_for=('GET', )
+        )
+        resource = MagicMock()
+        patched.from_colander.return_value = sentinel.schema
+        arguments = viewset.collection_arguments(resource, 'get')
+        patched.from_colander.assert_called_with(resource.mapping,
+                                                 bind_request=False)
+        self.assertEquals(arguments['schema'], sentinel.schema)
+
+    @patch('cliquet.resource.CorniceSchema')
+    def test_schema_is_not_added_when_method_does_not_match(self, patched):
+        viewset = ViewSet(
+            validate_schema_for=('GET', )
+        )
+        resource = MagicMock()
+        arguments = viewset.collection_arguments(resource, 'POST')
+        patched.from_colander.assert_not_called()
+        self.assertNotIn('schema', arguments)
+
+    def test_class_parameters_are_used_for_collection_arguments(self):
+        default_arguments = {
+            'description': 'This is one description of {resource_name}',
+        }
+        default_collection_arguments = {
+            'cors_origins': ('example.org',),
+        }
+
+        collection_get_arguments = {
+            'error_handler': sentinel.error_handler
+        }
+
+        viewset = ViewSet(
+            default_arguments=default_arguments,
+            default_collection_arguments=default_collection_arguments,
+            collection_get_arguments=collection_get_arguments
+        )
+
+        arguments = viewset.collection_arguments(MagicMock, 'get')
+        self.assertDictEqual(
+            arguments,
+            {
+                'description': 'This is one description of {resource_name}',
+                'cors_origins': ('example.org',),
+                'error_handler': sentinel.error_handler
+            }
+        )
+
+    def test_class_parameters_are_used_for_record_arguments(self):
+        default_arguments = {
+            'description': 'This is one description of {resource_name}',
+        }
+        default_record_arguments = {
+            'cors_origins': ('example.org',),
+        }
+
+        record_get_arguments = {
+            'error_handler': sentinel.error_handler
+        }
+
+        viewset = ViewSet(
+            default_arguments=default_arguments,
+            default_record_arguments=default_record_arguments,
+            record_get_arguments=record_get_arguments
+        )
+
+        arguments = viewset.record_arguments(MagicMock, 'get')
+        self.assertDictEqual(
+            arguments,
+            {
+                'description': 'This is one description of {resource_name}',
+                'cors_origins': ('example.org',),
+                'error_handler': sentinel.error_handler
+            }
+        )
+
+    def test_class_parameters_overwrite_each_others(self):
+        # Some class parameters should overwrite each others.
+        # The more specifics should prevail over the more generics.
+        # Items annoted with a "<<" are the one that should prevail.
+        default_arguments = {
+            'cors_origins': sentinel.default_cors_origins,
+            'error_handler': sentinel.default_error_handler,
+            'description': sentinel.default_description,  # <<
+        }
+        default_record_arguments = {
+            'cors_origins': sentinel.default_record_cors_origin,
+            'error_handler': sentinel.default_record_error_handler,  # <<
+        }
+
+        record_get_arguments = {
+            'cors_origins': sentinel.record_get_cors_origin,  # <<
+        }
+
+        viewset = ViewSet(
+            default_arguments=default_arguments,
+            default_record_arguments=default_record_arguments,
+            record_get_arguments=record_get_arguments,
+        )
+
+        arguments = viewset.record_arguments(MagicMock, 'get')
+        self.assertDictEqual(
+            arguments,
+            {
+                'description': sentinel.default_description,
+                'error_handler': sentinel.default_record_error_handler,
+                'cors_origins': sentinel.record_get_cors_origin,
+            }
+        )
+
+
+class RegisterTest(unittest.TestCase):
+
+    def setUp(self):
+        self.resource = FakeResource()
+        self.viewset = FakeViewSet()
+
+    @patch('cliquet.resource.Service')
+    def test_viewset_is_updated_if_provided(self, service_class):
+        additional_params = {'foo': 'bar'}
+        register(self.resource, viewset=self.viewset, **additional_params)
+        self.viewset.update.assert_called_with(**additional_params)
+
+    @patch('cliquet.resource.Service')
+    def test_collection_views_are_registered_in_cornice(self, service_class):
+        register(self.resource, viewset=self.viewset)
+
+        service_class.assert_any_call(self.resource.name, '/fake')
+        service_class().add_view.assert_any_call(
+            'GET', sentinel.collection_get)
+
+    @patch('cliquet.resource.Service')
+    def test_record_views_are_registered_in_cornice(self, service_class):
+        register(self.resource, viewset=self.viewset)
+
+        service_class.assert_any_call(self.resource.name, '/fake/{id}')
+        service_class().add_view.assert_any_call(
+            'PUT', sentinel.record_put)
+
+
+    @patch('cliquet.resource.Service')
+    def test_record_methods_are_skipped_if_not_enabled(self, service_class):
+        register(self.resource, viewset=self.viewset, settings={
+            'cliquet.record_fake_put_enabled': False
+        })
+
+        # Only the collection views should have been added.
+        # 3 calls: two registering the service classes,
+        # one for the collection_get
+        self.assertEquals(len(service_class.mock_calls), 3)
+        service_class.assert_any_call(self.resource.name, '/fake')
+        service_class().add_view.assert_any_call(
+            'GET', sentinel.collection_get)
+
+
+    @patch('cliquet.resource.Service')
+    def test_record_methods_are_skipped_if_not_enabled(self, service_class):
+        register(self.resource, viewset=self.viewset, settings={
+            'cliquet.collection_fake_get_enabled': False
+        })
+
+        # Only the collection views should have been added.
+        # 3 calls: two registering the service classes,
+        # one for the collection_get
+        self.assertEquals(len(service_class.mock_calls), 3)
+        service_class.assert_any_call(self.resource.name, '/fake/{id}')
+        service_class().add_view.assert_any_call(
+            'PUT', sentinel.record_put)
+

--- a/cliquet/tests/test_resource.py
+++ b/cliquet/tests/test_resource.py
@@ -4,7 +4,7 @@ from cliquet.resource import ViewSet, register
 
 from .support import unittest
 
-class FakeViewSet(object):
+class FakeViewSet(ViewSet):
     """Fake viewset class used for tests."""
     collection_path = "/{resource_name}"
     record_path = "/{resource_name}/{{id}}"
@@ -31,7 +31,10 @@ class FakeResource(object):
         # {type}_{method} will map to the sentinel with the same name.
         for typ_ in ('collection', 'record'):
             for method in ('get', 'put', 'patch', 'delete'):
-                view_name = '_'.join((typ_, method))
+                if typ_ == 'record':
+                    view_name = method
+                else:
+                    view_name = '_'.join((typ_, method))
                 setattr(self, view_name, getattr(sentinel, view_name))
 
 
@@ -202,7 +205,7 @@ class RegisterTest(unittest.TestCase):
 
         service_class.assert_any_call('fake-record', '/fake/{id}')
         service_class().add_view.assert_any_call(
-            'PUT', sentinel.record_put)
+            'PUT', sentinel.put)
 
 
     @patch('cliquet.resource.Service')
@@ -232,5 +235,5 @@ class RegisterTest(unittest.TestCase):
         self.assertEquals(len(service_class.mock_calls), 3)
         service_class.assert_any_call('fake-record', '/fake/{id}')
         service_class().add_view.assert_any_call(
-            'PUT', sentinel.record_put)
+            'PUT', sentinel.put)
 

--- a/cliquet/tests/testapp/__init__.py
+++ b/cliquet/tests/testapp/__init__.py
@@ -2,6 +2,7 @@ from pyramid.config import Configurator
 import cliquet
 from cliquet.tests.testapp import views
 
+
 def includeme(config):
     config.scan("cliquet.tests.testapp.views")
 

--- a/cliquet/tests/testapp/__init__.py
+++ b/cliquet/tests/testapp/__init__.py
@@ -1,12 +1,15 @@
 from pyramid.config import Configurator
 import cliquet
-
+from cliquet.tests.testapp import views
 
 def includeme(config):
     config.scan("cliquet.tests.testapp.views")
 
 
-def main(settings=None):
+def main(settings=None, *args, **additional_settings):
+    if settings is None:
+        settings = {}
+    settings.update(additional_settings)
     config = Configurator(settings=settings)
     cliquet.initialize(config, version='0.0.1')
     config.include(includeme)

--- a/cliquet/tests/testapp/views.py
+++ b/cliquet/tests/testapp/views.py
@@ -1,4 +1,4 @@
-from cliquet.resource import BaseResource, ResourceSchema, crud
+from cliquet.resource import BaseResource, ResourceSchema, register
 import colander
 
 
@@ -6,6 +6,7 @@ class MushroomSchema(ResourceSchema):
     name = colander.SchemaNode(colander.String())
 
 
-@crud()
 class Mushroom(BaseResource):
     mapping = MushroomSchema()
+
+register(Mushroom)

--- a/cliquet/tests/testapp/views.py
+++ b/cliquet/tests/testapp/views.py
@@ -5,8 +5,6 @@ import colander
 class MushroomSchema(ResourceSchema):
     name = colander.SchemaNode(colander.String())
 
-
+@register()
 class Mushroom(BaseResource):
     mapping = MushroomSchema()
-
-register(Mushroom)

--- a/cliquet/tests/testapp/views.py
+++ b/cliquet/tests/testapp/views.py
@@ -5,6 +5,7 @@ import colander
 class MushroomSchema(ResourceSchema):
     name = colander.SchemaNode(colander.String())
 
+
 @register()
 class Mushroom(BaseResource):
     mapping = MushroomSchema()

--- a/cliquet/views/batch.py
+++ b/cliquet/views/batch.py
@@ -1,7 +1,6 @@
 import colander
 import six
 
-from cornice import Service
 from pyramid.request import Request
 from pyramid.security import NO_PERMISSION_REQUIRED
 from pyramid import httpexceptions
@@ -9,6 +8,7 @@ from six.moves.urllib import parse as urlparse
 
 from cliquet import errors
 from cliquet import logger
+from cliquet import Service
 from cliquet.utils import json, merge_dicts
 
 

--- a/cliquet/views/heartbeat.py
+++ b/cliquet/views/heartbeat.py
@@ -1,6 +1,6 @@
-from cornice import Service
 from pyramid.security import NO_PERMISSION_REQUIRED
 
+from cliquet import Service
 
 heartbeat = Service(name="heartbeat", path='/__heartbeat__',
                     description="Server health")

--- a/cliquet/views/hello.py
+++ b/cliquet/views/hello.py
@@ -1,6 +1,6 @@
-from cornice import Service
 from pyramid.security import NO_PERMISSION_REQUIRED
 
+from cliquet import Service
 
 hello = Service(name="hello", path='/', description="Welcome")
 


### PR DESCRIPTION
(Alex's edit of empty description)

This pull request does:

- [x] Refactor the `@crud` decorator into a `register_resource` function and a `ViewSet` class;
- [x] Add unit tests for these two;
- [x] Document the new additions;
- [x] Create a cliquet subclass of `cornice.Service` to avoid cluttering the cornice namespace;
- [x] Handle `readonly` and `readwrite` permissions;
- [x] Handle CORS in a better way than before;
- [x] Make the functional tests pass.