### PR TITLE
Switch to cache/concurrency control to Etag (fixes #251)

### DIFF
--- a/cliquet/resource.py
+++ b/cliquet/resource.py
@@ -681,8 +681,7 @@ class BaseResource(object):
         # Pyramid takes care of converting.
         response.last_modified = timestamp / 1000.0
         # Return timestamp as ETag.
-        timestamp = six.text_type(timestamp).encode('utf-8')
-        response.headers['ETag'] = '"%s"' % timestamp
+        response.headers['ETag'] = ('"%s"' % timestamp).encode('utf-8')
 
     def _raise_400_if_invalid_id(self, record_id):
         """Raise 400 if specified record id does not match the format excepted
@@ -707,6 +706,8 @@ class BaseResource(object):
 
         if not if_none_match:
             return
+
+        if_none_match = if_none_match.decode('utf-8')
 
         try:
             assert if_none_match[0] == if_none_match[-1] == '"'
@@ -742,7 +743,9 @@ class BaseResource(object):
         if not if_match and not if_none_match:
             return
 
-        if if_none_match == '*':
+        if_match = if_match.decode('utf-8') if if_match else None
+
+        if if_none_match and if_none_match.decode('utf-8') == '*':
             modified_since = -1  # Always raise.
         elif if_match:
             try:

--- a/cliquet/resource.py
+++ b/cliquet/resource.py
@@ -50,12 +50,12 @@ class ViewSet(object):
 
     default_collection_arguments = {}
     collection_get_arguments = {
-        'cors_headers': ('Next-Page', 'Total-Records', 'Last-Modified')
+        'cors_headers': ('Next-Page', 'Total-Records', 'Last-Modified', 'ETag')
     }
 
     default_record_arguments = {}
     record_get_arguments = {
-        'cors_headers': ('Last-Modified',)
+        'cors_headers': ('Last-Modified', 'ETag')
     }
 
     def __init__(self, **kwargs):
@@ -672,12 +672,17 @@ class BaseResource(object):
                                   errno=ERRORS.INVALID_RESOURCE_ID)
             raise response
 
-    def _add_timestamp_header(self, response):
+    def _add_timestamp_header(self, response, timestamp=None):
         """Add current timestamp in response headers, when request comes in.
 
         """
-        timestamp = six.text_type(self.timestamp).encode('utf-8')
-        response.headers['Last-Modified'] = timestamp
+        if timestamp is None:
+            timestamp = self.timestamp
+        # Pyramid takes care of converting.
+        response.last_modified = timestamp / 1000.0
+        # Return timestamp as ETag.
+        timestamp = six.text_type(timestamp).encode('utf-8')
+        response.headers['ETag'] = '"%s"' % timestamp
 
     def _raise_400_if_invalid_id(self, record_id):
         """Raise 400 if specified record id does not match the format excepted
@@ -698,20 +703,33 @@ class BaseResource(object):
 
         :raises: :exc:`~pyramid:pyramid.httpexceptions.HTTPNotModified`
         """
-        modified_since = self.request.headers.get('If-Modified-Since')
+        if_none_match = self.request.headers.get('If-None-Match')
 
-        if modified_since:
-            modified_since = int(modified_since)
+        if not if_none_match:
+            return
 
-            if record:
-                current_timestamp = record[self.collection.modified_field]
+        try:
+            assert if_none_match[0] == if_none_match[-1] == '"'
+            modified_since = int(if_none_match[1:-1])
+        except (IndexError, AssertionError, ValueError):
+            if if_none_match == '*':
+                modified_since = -1  # Always true.
             else:
-                current_timestamp = self.collection.timestamp()
+                error_details = {
+                    'location': 'headers',
+                    'description': "Invalid value for If-None-Match"
+                }
+                raise_invalid(self.request, **error_details)
 
-            if current_timestamp <= modified_since:
-                response = HTTPNotModified()
-                self._add_timestamp_header(response)
-                raise response
+        if record:
+            current_timestamp = record[self.collection.modified_field]
+        else:
+            current_timestamp = self.collection.timestamp()
+
+        if current_timestamp <= modified_since:
+            response = HTTPNotModified()
+            self._add_timestamp_header(response, timestamp=current_timestamp)
+            raise response
 
     def _raise_412_if_modified(self, record=None):
         """Raise 412 if current timestamp is superior to the one
@@ -720,23 +738,34 @@ class BaseResource(object):
         :raises:
             :exc:`~pyramid:pyramid.httpexceptions.HTTPPreconditionFailed`
         """
-        unmodified_since = self.request.headers.get('If-Unmodified-Since')
+        if_match = self.request.headers.get('If-Match')
 
-        if unmodified_since:
-            unmodified_since = int(unmodified_since)
+        if not if_match:
+            return
 
-            if record:
-                current_timestamp = record[self.collection.modified_field]
-            else:
-                current_timestamp = self.collection.timestamp()
+        try:
+            assert if_match[0] == if_match[-1] == '"'
+            modified_since = int(if_match[1:-1])
+        except (IndexError, AssertionError, ValueError):
+            error_details = {
+                'location': 'headers',
+                'description': "Invalid value for If-Match"
+            }
+            raise_invalid(self.request, **error_details)
 
-            if current_timestamp > unmodified_since:
-                error_msg = 'Resource was modified meanwhile'
-                response = http_error(HTTPPreconditionFailed(),
-                                      errno=ERRORS.MODIFIED_MEANWHILE,
-                                      message=error_msg)
-                self._add_timestamp_header(response)
-                raise response
+        if record:
+            current_timestamp = record[self.modified_field]
+        else:
+            current_timestamp = self.storage.collection_timestamp(
+                **self.storage_kw)
+
+        if current_timestamp > modified_since:
+            error_msg = 'Resource was modified meanwhile'
+            response = http_error(HTTPPreconditionFailed(),
+                                  errno=ERRORS.MODIFIED_MEANWHILE,
+                                  message=error_msg)
+            self._add_timestamp_header(response, timestamp=current_timestamp)
+            raise response
 
     def _raise_conflict(self, exception):
         """Helper to raise conflict responses.

--- a/cliquet/tests/resource/test_preconditions.py
+++ b/cliquet/tests/resource/test_preconditions.py
@@ -1,4 +1,3 @@
-import six
 from pyramid import httpexceptions
 
 from cliquet.errors import ERRORS
@@ -45,17 +44,17 @@ class NotModifiedTest(BaseTest):
         self.assertNotIn('1970', error.headers['Last-Modified'])
 
     def test_if_none_match_empty_raises_invalid(self):
-        self.resource.request.headers['If-None-Match'] = '""'
+        self.resource.request.headers['If-None-Match'] = '""'.encode('utf-8')
         self.assertRaises(httpexceptions.HTTPBadRequest,
                           self.resource.collection_get)
 
     def test_if_none_match_without_quotes_raises_invalid(self):
-        self.resource.request.headers['If-None-Match'] = '12345'
+        self.resource.request.headers['If-None-Match'] = '1234'.encode('utf-8')
         self.assertRaises(httpexceptions.HTTPBadRequest,
                           self.resource.collection_get)
 
     def test_if_none_match_not_integer_raises_invalid(self):
-        self.resource.request.headers['If-None-Match'] = '"abc"'
+        self.resource.request.headers['If-None-Match'] = '"ab"'.encode('utf-8')
         self.assertRaises(httpexceptions.HTTPBadRequest,
                           self.resource.collection_get)
 
@@ -65,9 +64,10 @@ class ModifiedMeanwhileTest(BaseTest):
         super(ModifiedMeanwhileTest, self).setUp()
         self.stored = self.collection.create_record({})
         self.resource.collection_get()
-        current = self.last_response.headers['ETag'][1:-1]
-        previous = six.text_type(int(current) - 10).encode('utf-8')
-        self.resource.request.headers['If-Match'] = '"%s"' % previous
+        current = self.last_response.headers['ETag'][1:-1].decode('utf-8')
+        previous = int(current) - 10
+        if_match = ('"%s"' % previous).encode('utf-8')
+        self.resource.request.headers['If-Match'] = if_match
 
     def test_preconditions_errors_are_json_formatted(self):
         try:
@@ -132,7 +132,7 @@ class ModifiedMeanwhileTest(BaseTest):
 
     def test_if_none_match_star_fails_if_record_exists(self):
         self.resource.request.headers.pop('If-Match')
-        self.resource.request.headers['If-None-Match'] = '*'
+        self.resource.request.headers['If-None-Match'] = '*'.encode('utf-8')
         self.resource.record_id = self.stored['id']
         self.assertRaises(httpexceptions.HTTPPreconditionFailed,
                           self.resource.put)
@@ -164,16 +164,16 @@ class ModifiedMeanwhileTest(BaseTest):
                           self.resource.collection_delete)
 
     def test_if_match_without_quotes_raises_invalid(self):
-        self.resource.request.headers['If-Match'] = '123456'
+        self.resource.request.headers['If-Match'] = '123456'.encode('utf-8')
         self.assertRaises(httpexceptions.HTTPBadRequest,
                           self.resource.collection_get)
 
     def test_if_match_empty_raises_invalid(self):
-        self.resource.request.headers['If-Match'] = '""'
+        self.resource.request.headers['If-Match'] = '""'.encode('utf-8')
         self.assertRaises(httpexceptions.HTTPBadRequest,
                           self.resource.collection_get)
 
     def test_if_match_not_integer_raises_invalid(self):
-        self.resource.request.headers['If-Match'] = '"abc"'
+        self.resource.request.headers['If-Match'] = '"abc"'.encode('utf-8')
         self.assertRaises(httpexceptions.HTTPBadRequest,
                           self.resource.collection_get)

--- a/cliquet/tests/resource/test_preconditions.py
+++ b/cliquet/tests/resource/test_preconditions.py
@@ -130,11 +130,15 @@ class ModifiedMeanwhileTest(BaseTest):
         self.assertRaises(httpexceptions.HTTPPreconditionFailed,
                           self.resource.put)
 
-    def test_if_none_match_star_is_equivalent_to_zero(self):
+    def test_if_none_match_star_fails_if_record_exists(self):
+        self.resource.request.headers.pop('If-Match')
         self.resource.request.headers['If-None-Match'] = '*'
         self.resource.record_id = self.stored['id']
         self.assertRaises(httpexceptions.HTTPPreconditionFailed,
                           self.resource.put)
+        self.resource.request.validated = {'data': {'field': 'new'}}
+        self.resource.record_id = self.resource.collection.id_generator()
+        self.resource.put()  # not raising.
 
     def test_patch_returns_412_if_changed_meanwhile(self):
         self.resource.record_id = self.stored['id']

--- a/cliquet/tests/resource/test_record.py
+++ b/cliquet/tests/resource/test_record.py
@@ -98,8 +98,8 @@ class PatchTest(BaseTest):
         self.resource.patch()
         self.resource = BaseResource(self.get_request())
         self.resource.collection_get()['data']
-        last_modified = self.last_response.headers['Last-Modified']
-        self.assertEquals(self.result['last_modified'], int(last_modified))
+        last_modified = int(self.last_response.headers['ETag'][1:-1])
+        self.assertEquals(self.result['last_modified'], last_modified)
 
     def test_timestamp_is_not_updated_if_no_change_after_preprocessed(self):
         with mock.patch.object(self.resource, 'process_record') as mocked:

--- a/cliquet/tests/resource/test_sync.py
+++ b/cliquet/tests/resource/test_sync.py
@@ -37,7 +37,7 @@ class SinceModifiedTest(ThreadMixin, BaseTest):
         modification = result['last_modified']
         self.resource = BaseResource(self.get_request())
         self.resource.collection_get()
-        header = int(self.last_response.headers['Last-Modified'])
+        header = int(self.last_response.headers['ETag'][1:-1])
         self.assertEqual(header, modification)
 
     def test_filter_with_since_accepts_numeric_value(self):
@@ -79,7 +79,7 @@ class SinceModifiedTest(ThreadMixin, BaseTest):
 
     def test_filter_from_last_header_value_is_exclusive(self):
         self.resource.collection_get()
-        current = int(self.last_response.headers['Last-Modified'])
+        current = int(self.last_response.headers['ETag'][1:-1])
 
         self.resource.request.GET = {'_since': six.text_type(current)}
         result = self.resource.collection_get()
@@ -95,7 +95,7 @@ class SinceModifiedTest(ThreadMixin, BaseTest):
 
         def read_timestamp():
             self.resource.collection_get()
-            return int(self.last_response.headers['Last-Modified'])
+            return int(self.last_response.headers['ETag'][1:-1])
 
         before = read_timestamp()
         now = read_timestamp()
@@ -128,7 +128,7 @@ class SinceModifiedTest(ThreadMixin, BaseTest):
             with mock.patch.object(self.collection.storage,
                                    'get_all', delayed_get):
                 self.resource.collection_get()
-                fetch_at = self.last_response.headers['Last-Modified']
+                fetch_at = self.last_response.headers['ETag'][1:-1]
                 timestamps['fetch'] = int(fetch_at)
 
         # Create a real record with no patched timestamp

--- a/cliquet/tests/resource/test_views_cors.py
+++ b/cliquet/tests/resource/test_views_cors.py
@@ -105,7 +105,7 @@ class CORSExposeHeadersTest(BaseWebTest):
 
     def test_collection_get_exposes_every_possible_header(self):
         self.assert_expose_headers('GET', self.collection_url, [
-            'Alert', 'Backoff', 'Last-Modified', 'Next-Page',
+            'Alert', 'Backoff', 'ETag', 'Last-Modified', 'Next-Page',
             'Retry-After', 'Total-Records'])
 
     def test_hello_endpoint_exposes_only_minimal_set_of_headers(self):
@@ -120,7 +120,7 @@ class CORSExposeHeadersTest(BaseWebTest):
                                   status=201)
         record_url = self.get_item_url(resp.json['data']['id'])
         self.assert_expose_headers('GET', record_url, [
-            'Alert', 'Backoff', 'Retry-After', 'Last-Modified'])
+            'Alert', 'Backoff', 'ETag', 'Retry-After', 'Last-Modified'])
 
     def test_record_post_exposes_only_minimal_set_of_headers(self):
         body = {'data': MINIMALIST_RECORD}

--- a/cliquet/tests/test_logging.py
+++ b/cliquet/tests/test_logging.py
@@ -276,7 +276,7 @@ class ResourceInfoTest(BaseWebTest, unittest.TestCase):
         r = self.app.get('/mushrooms', headers=self.headers)
         event_dict = logger_context()
         self.assertEqual(event_dict['collection_timestamp'],
-                         int(r.headers['Last-Modified']))
+                         int(r.headers['ETag'][1:-1]))
 
     def test_result_size_and_limit_are_bound(self):
         for name in ['a', 'b', 'c']:

--- a/docs/api/resource.rst
+++ b/docs/api/resource.rst
@@ -365,9 +365,6 @@ containing:
 
 - ``data``: the record with exhaustive schema fields.
 
-For convenience and consistency, a header ``ETag`` will also repeat the
-value of the ``last_modified`` field.
-
 If the request header ``If-None-Match`` is provided, and if the record has not
 changed meanwhile, a ``304 Not Modified`` is returned.
 

--- a/docs/api/timestamps.rst
+++ b/docs/api/timestamps.rst
@@ -4,20 +4,56 @@
 Server timestamps
 #################
 
-The ``Last-Modified`` header with the current timestamp of the collection for
-the current user will be given on collection and record GET endpoints.
-
-::
-
-    Last-Modified: 1422375916186
-
-
-In order to bypass costly and error-prone HTTP date parsing, timestamps are
-not true HTTP date values.
-
-Timestamps are **milliseconds** EPOCH timestamps,
-
 In order to avoid race conditions, *Cliquet* guarantees that each change will
 increment the timestamp of the related collection.
 If two changes happen at the same millisecond, they will still have two differents
 timestamps.
+
+The ``ETag`` header with the current timestamp of the collection for
+the current user will be given on collection and record GET endpoints.
+
+::
+
+    ETag: "1432208041618"
+
+
+In order to bypass costly and error-prone HTTP date parsing, ``ETag`` headers
+are not HTTP date values.
+
+A human readable version of the timestamp (rounded to second) is provided though
+in the ``Last-Modified`` response headers:
+
+::
+
+    Last-Modified: Wed May 20 17:22:38 2015 +0200
+
+
+.. versionchanged:: 2.0
+
+    In previous versions, cache and concurrency control was handled using
+    ``If-Modified-Since`` and ``If-Unmodified-Since``. But since the HTTP date
+    does not include milliseconds, they contained the milliseconds timestamp as
+    integer. The current version using ``ETag`` is HTTP compliant.
+
+    (*see `original discussion <https://github.com/mozilla-services/cliquet/issues/251>`_*)
+
+
+Cache control
+=============
+
+In order to check that the client version has not changed, a ``If-None-Match``
+request header can be used. If the response is ``304 Not Modified`` then
+the cached version if still good.
+
+
+Concurrency control
+===================
+
+In order to prevent race conditions, like overwriting changes occured in the interim for example,
+a ``If-Match`` request header can be used. If the response is ``412 Precondition failed``
+then the resource has changed meanwhile.
+
+The client can then choose to:
+
+* overwrite by repeating the request without ``If-Match``;
+* reconcile the resource by fetching, merging and repeating the request.

--- a/docs/api/timestamps.rst
+++ b/docs/api/timestamps.rst
@@ -37,6 +37,11 @@ in the ``Last-Modified`` response headers:
 
     (*see `original discussion <https://github.com/mozilla-services/cliquet/issues/251>`_*)
 
+.. note::
+
+    The client may send ``If-Unmodified-Since`` or ``If-Modified-Since`` requests
+    headers, but in the current implementation, they will be ignored.
+
 
 Cache control
 =============


### PR DESCRIPTION
* [x] Replaced IMS/IUMS by If-Match/If-None-Match
* [x] Added ``ETag`` CORS exposed headers 
* [x] Updated resource endpoint docs
* [x] Completed timestamps section docs
* [x] Made sure the ETag returned with 412 is the one of record, not whole collection

@Natim @ametaireau  r? 

Questions:

* Should we still support IMS and IUMS headers using HTTP date even if their equivalent timestamp value is rounded to second ?
   * *I don't think so because there would be two ways to achieve the same goal*
* Did I manage ``If-None-Match: *`` properly ?

**note:**
Tests fails because of random CloudStorage backend ``BackendError: ConnectionError: ('Connection aborted.', error(104, 'Connection reset by peer'))``

