### PR TITLE
Introduce permissions in resource

### DIFF
--- a/cliquet/resource.py
+++ b/cliquet/resource.py
@@ -983,32 +983,38 @@ class ProtectedResource(BaseResource):
                 permissions[perm] = list(principals)
         return permissions
 
+    def _unprefixed_path(self):
+        return re.sub(r'^(/v\d+)?', '', self.request.path)
+
     def collection_post(self):
         result = super(ProtectedResource, self).collection_post()
 
         object_id = result['data'][self.collection.id_field]
+
+        # XXX: request.route_url() for record service ?
+        object_id = self._unprefixed_path() + '/' + object_id
         result['permissions'] = self._store_permissions(object_id=object_id)
         return result
 
     def get(self):
         result = super(ProtectedResource, self).get()
 
-        object_id = self.request.path
+        object_id = self._unprefixed_path()
         result['permissions'] = self._build_permissions(object_id=object_id)
         return result
 
     def put(self):
         result = super(ProtectedResource, self).put()
 
-        object_id = self.request.path
-        result['permissions'] = self._store_permissions(object_id=object_id,
-                                                        replace=True)
+        object_id = self._unprefixed_path()
+        self._store_permissions(object_id=object_id, replace=True)
+        result['permissions'] = self._build_permissions(object_id=object_id)
         return result
 
     def patch(self):
         result = super(ProtectedResource, self).patch()
 
-        object_id = self.request.path
+        object_id = self._unprefixed_path()
         self._store_permissions(object_id=object_id)
         result['permissions'] = self._build_permissions(object_id=object_id)
         return result

--- a/cliquet/resource.py
+++ b/cliquet/resource.py
@@ -364,10 +364,9 @@ class BaseResource(object):
             unique_fields = self.mapping.get_option('unique_fields')
             record = self.collection.create_record(new_record,
                                                    unique_fields=unique_fields)
+            self.request.response.status_code = 201
         except storage_exceptions.UnicityError as e:
-            return e.record
-
-        self.request.response.status_code = 201
+            record = e.record
 
         body = {
             'data': record,

--- a/cliquet/resource.py
+++ b/cliquet/resource.py
@@ -86,15 +86,25 @@ class ViewSet(object):
         method_args = getattr(self, by_method, {})
         args.update(**method_args)
 
-        if method.lower() in map(str.lower, self.validate_schema_for):
-            class RecordPayload(colander.MappingSchema):
-                data = resource.mapping
-            args['schema'] = RecordPayload()
-        else:
-            # Simply validate that posted body is a mapping.
-            args['schema'] = colander.MappingSchema(unknown='preserve')
+        args['schema'] = self.get_record_schema(resource, method)
 
         return args
+
+    def get_record_schema(self, resource, method):
+        """Return the Cornice schema for the given method.
+        """
+        if method.lower() not in map(str.lower, self.validate_schema_for):
+            # Simply validate that posted body is a mapping.
+            return colander.MappingSchema(unknown='preserve')
+
+        class RecordPayload(colander.MappingSchema):
+            data = resource.mapping
+            # XXX: permissions = PermissionSchema()
+
+            def schema_type(self, **kw):
+                return colander.Mapping(unknown='raise')
+
+        return RecordPayload()
 
     def get_view(self, endpoint_type, method):
         """Return the view method name located on the resource object, for the

--- a/cliquet/resource.py
+++ b/cliquet/resource.py
@@ -955,11 +955,11 @@ class ProtectedResource(BaseResource):
             return {}
 
         registry = self.request.registry
-        add_principal = registry.permission.add_object_permission_principal
+        add_principal = registry.permission.add_principal_to_ace
 
         # XXX: change permissions API.
         get_perm_principals = registry.permission.object_permission_principals
-        del_principal = registry.permission.remove_object_permission_principal
+        del_principal = registry.permission.remove_principal_from_ace
 
         if replace:
             for permission in self.permissions:
@@ -982,12 +982,6 @@ class ProtectedResource(BaseResource):
             if principals:
                 permissions[perm] = list(principals)
         return permissions
-
-    def collection_get(self):
-        result = super(ProtectedResource, self).collection_get()
-        object_id = self.request.path
-        result['permissions'] = self._build_permissions(object_id=object_id)
-        return result
 
     def collection_post(self):
         result = super(ProtectedResource, self).collection_post()

--- a/cliquet/resource.py
+++ b/cliquet/resource.py
@@ -944,3 +944,37 @@ class BaseResource(object):
             token[field] = last_record[field]
 
         return encode64(json.dumps(token))
+
+
+class ProtectedResource(BaseResource):
+    permissions = ('read', 'write')
+
+    def _build_permissions(self):
+        object_id = self.request.path
+        registry = self.request.registry
+        get_perm_principals = registry.permission.object_permission_principals
+
+        permissions = {}
+        for perm in self.permissions:
+            permissions[perm] = get_perm_principals(object_id, perm)
+        return permissions
+
+    def collection_get(self):
+        result = super(ProtectedResource, self).collection_get()
+        result['permissions'] = self._build_permissions()
+        return result
+
+    def get(self):
+        result = super(ProtectedResource, self).get()
+        result['permissions'] = self._build_permissions()
+        return result
+
+    def put(self):
+        result = super(ProtectedResource, self).put()
+        result['permissions'] = self._build_permissions()
+        return result
+
+    def patch(self):
+        result = super(ProtectedResource, self).patch()
+        result['permissions'] = self._build_permissions()
+        return result

--- a/cliquet/schema.py
+++ b/cliquet/schema.py
@@ -47,7 +47,6 @@ class ResourceSchema(colander.MappingSchema):
                 class Options:
                     preserve_unknown = True
         """
-
     def get_option(self, attr):
         default_value = getattr(ResourceSchema.Options, attr)
         return getattr(self.Options, attr,  default_value)

--- a/cliquet/tests/resource/__init__.py
+++ b/cliquet/tests/resource/__init__.py
@@ -6,9 +6,11 @@ from cliquet.resource import BaseResource
 
 
 class BaseTest(unittest.TestCase):
+    resource_class = BaseResource
+
     def setUp(self):
         self.storage = memory.Memory()
-        self.resource = BaseResource(self.get_request())
+        self.resource = self.resource_class(self.get_request())
         self.collection = self.resource.collection
         self.patch_known_field = mock.patch.object(self.resource,
                                                    'is_known_field')

--- a/cliquet/tests/resource/test_filter.py
+++ b/cliquet/tests/resource/test_filter.py
@@ -22,28 +22,28 @@ class FilteringTest(BaseTest):
         self.collection.delete_record(r)
         self.resource.request.GET = {'_since': '%s' % since, 'deleted': 'true'}
         result = self.resource.collection_get()
-        self.assertEqual(len(result['items']), 1)
-        self.assertTrue(result['items'][0]['deleted'])
+        self.assertEqual(len(result['data']), 1)
+        self.assertTrue(result['data'][0]['deleted'])
 
     def test_filter_on_id_is_supported(self):
         self.patch_known_field.stop()
         r = self.collection.create_record({})
         self.resource.request.GET = {'id': '%s' % r['id']}
         result = self.resource.collection_get()
-        self.assertEqual(result['items'][0], r)
+        self.assertEqual(result['data'][0], r)
 
     def test_list_cannot_be_filtered_on_deleted_without_since(self):
         r = self.collection.create_record({})
         self.collection.delete_record(r)
         self.resource.request.GET = {'deleted': 'true'}
         result = self.resource.collection_get()
-        self.assertEqual(len(result['items']), 0)
+        self.assertEqual(len(result['data']), 0)
 
     def test_filter_works_with_empty_list(self):
         self.resource.collection.parent_id = 'alice'
         self.resource.request.GET = {'status': '1'}
         result = self.resource.collection_get()
-        self.assertEqual(len(result['items']), 0)
+        self.assertEqual(len(result['data']), 0)
 
     def test_number_of_records_matches_filter(self):
         self.resource.request.GET = {'status': '1'}
@@ -54,7 +54,7 @@ class FilteringTest(BaseTest):
     def test_single_basic_filter_by_attribute(self):
         self.resource.request.GET = {'status': '1'}
         result = self.resource.collection_get()
-        self.assertEqual(len(result['items']), 2)
+        self.assertEqual(len(result['data']), 2)
 
     def test_filter_on_unknown_attribute_raises_error(self):
         self.patch_known_field.stop()
@@ -87,52 +87,52 @@ class FilteringTest(BaseTest):
     def test_double_basic_filter_by_attribute(self):
         self.resource.request.GET = {'status': '1', 'favorite': 'true'}
         result = self.resource.collection_get()
-        self.assertEqual(len(result['items']), 1)
+        self.assertEqual(len(result['data']), 1)
 
     def test_string_filters_naively_by_value(self):
         self.resource.request.GET = {'title': 'MoF'}
         result = self.resource.collection_get()
-        self.assertEqual(len(result['items']), 0)
+        self.assertEqual(len(result['data']), 0)
         self.resource.request.GET = {'title': 'MoFo'}
         result = self.resource.collection_get()
-        self.assertEqual(len(result['items']), 6)
+        self.assertEqual(len(result['data']), 6)
 
     def test_filter_considers_string_if_syntaxically_invalid(self):
         self.resource.request.GET = {'status': '1.2.3'}
         result = self.resource.collection_get()
-        self.assertEqual(len(result['items']), 0)
+        self.assertEqual(len(result['data']), 0)
 
     def test_filter_does_not_fail_with_complex_type_syntax(self):
         self.resource.request.GET = {'status': '(1,2,3)'}
         result = self.resource.collection_get()
-        self.assertEqual(len(result['items']), 0)
+        self.assertEqual(len(result['data']), 0)
 
     def test_different_value(self):
         self.resource.request.GET = {'not_status': '2'}
         result = self.resource.collection_get()
-        values = [item['status'] for item in result['items']]
+        values = [item['status'] for item in result['data']]
         self.assertTrue(all([value != 2 for value in values]))
 
     def test_minimal_value(self):
         self.resource.request.GET = {'min_status': '2'}
         result = self.resource.collection_get()
-        values = [item['status'] for item in result['items']]
+        values = [item['status'] for item in result['data']]
         self.assertTrue(all([value >= 2 for value in values]))
 
     def test_gt_value(self):
         self.resource.request.GET = {'gt_status': '2'}
         result = self.resource.collection_get()
-        values = [item['status'] for item in result['items']]
+        values = [item['status'] for item in result['data']]
         self.assertTrue(all([value > 2 for value in values]))
 
     def test_maximal_value(self):
         self.resource.request.GET = {'max_status': '2'}
         result = self.resource.collection_get()
-        values = [item['status'] for item in result['items']]
+        values = [item['status'] for item in result['data']]
         self.assertTrue(all([value <= 2 for value in values]))
 
     def test_lt_value(self):
         self.resource.request.GET = {'lt_status': '2'}
         result = self.resource.collection_get()
-        values = [item['status'] for item in result['items']]
+        values = [item['status'] for item in result['data']]
         self.assertTrue(all([value < 2 for value in values]))

--- a/cliquet/tests/resource/test_object_permissions.py
+++ b/cliquet/tests/resource/test_object_permissions.py
@@ -31,14 +31,19 @@ class ObtainCollectionPermissionTest(PermissionTest):
     def test_permissions_are_provided_in_collection_get(self):
         self.assertIn('permissions', self.result)
 
+    def test_permissions_are_provided_in_collection_post(self):
+        self.resource.request.validated = {'data': {}}
+        result = self.resource.collection_post()
+        self.assertIn('permissions', result)
+
     def test_permissions_are_not_provided_in_collection_delete(self):
         result = self.resource.collection_delete()
         self.assertNotIn('permissions', result)
 
     def test_permissions_gives_lists_of_principals_per_ace(self):
         permissions = self.result['permissions']
-        self.assertEqual(permissions['read'], {'fxa:user'})
-        self.assertEqual(permissions['write'], {'fxa:user'})
+        self.assertEqual(permissions['read'], ['fxa:user'])
+        self.assertEqual(permissions['write'], ['fxa:user'])
 
 
 class ObtainRecordPermissionTest(PermissionTest):
@@ -76,5 +81,46 @@ class ObtainRecordPermissionTest(PermissionTest):
     def test_permissions_gives_lists_of_principals_per_ace(self):
         result = self.resource.get()
         permissions = result['permissions']
-        self.assertEqual(permissions['read'], {'fxa:user'})
-        self.assertEqual(permissions['write'], {'fxa:user'})
+        self.assertEqual(permissions['read'], ['fxa:user'])
+        self.assertEqual(permissions['write'], ['fxa:user'])
+
+
+class SpecifyCollectionPermissionTest(PermissionTest):
+    def setUp(self):
+        super(SpecifyCollectionPermissionTest, self).setUp()
+        self.resource.request.path = '/articles'
+
+    def test_permissions_can_be_specified_in_collection_post(self):
+        perms = {'write': ['jean-louis']}
+        self.resource.request.validated = {'data': {}, 'permissions': perms}
+        result = self.resource.collection_post()
+        self.assertEqual(result['permissions'],
+                         {'write': ['jean-louis']})
+
+
+class SpecifyRecordPermissionTest(PermissionTest):
+    def setUp(self):
+        super(SpecifyRecordPermissionTest, self).setUp()
+        record = self.resource.collection.create_record({})
+        record_id = record['id']
+        record_uri = '/articles/%s' % record_id
+        self.permission.add_object_permission_principal(record_uri,
+                                                        'read',
+                                                        'fxa:user')
+        self.resource.record_id = record_id
+        self.resource.request.validated = {'data': {}}
+        self.resource.request.path = record_uri
+
+    def test_permissions_are_replaced_with_put(self):
+        perms = {'write': ['jean-louis']}
+        self.resource.request.validated['permissions'] = perms
+        result = self.resource.put()
+        self.assertEqual(result['permissions'], perms)
+
+    def test_permissions_are_modified_with_patch(self):
+        perms = {'write': ['jean-louis']}
+        self.resource.request.validated['permissions'] = perms
+        result = self.resource.patch()
+        self.assertEqual(result['permissions'],
+                         {'write': ['jean-louis'],
+                          'read': ['fxa:user']})

--- a/cliquet/tests/resource/test_object_permissions.py
+++ b/cliquet/tests/resource/test_object_permissions.py
@@ -1,0 +1,80 @@
+from cliquet.resource import ProtectedResource
+from cliquet.tests.resource import BaseTest
+from cliquet.permission.memory import Memory
+
+
+class PermissionTest(BaseTest):
+    resource_class = ProtectedResource
+
+    def setUp(self):
+        self.permission = Memory()
+        super(PermissionTest, self).setUp()
+
+    def get_request(self):
+        request = super(PermissionTest, self).get_request()
+        request.registry.permission = self.permission
+        return request
+
+
+class ObtainCollectionPermissionTest(PermissionTest):
+    def setUp(self):
+        super(ObtainCollectionPermissionTest, self).setUp()
+        self.permission.add_object_permission_principal('/articles',
+                                                        'read',
+                                                        'fxa:user')
+        self.permission.add_object_permission_principal('/articles',
+                                                        'write',
+                                                        'fxa:user')
+        self.resource.request.path = '/articles'
+        self.result = self.resource.collection_get()
+
+    def test_permissions_are_provided_in_collection_get(self):
+        self.assertIn('permissions', self.result)
+
+    def test_permissions_are_not_provided_in_collection_delete(self):
+        result = self.resource.collection_delete()
+        self.assertNotIn('permissions', result)
+
+    def test_permissions_gives_lists_of_principals_per_ace(self):
+        permissions = self.result['permissions']
+        self.assertEqual(permissions['read'], {'fxa:user'})
+        self.assertEqual(permissions['write'], {'fxa:user'})
+
+
+class ObtainRecordPermissionTest(PermissionTest):
+    def setUp(self):
+        super(ObtainRecordPermissionTest, self).setUp()
+        record = self.resource.collection.create_record({})
+        record_id = record['id']
+        record_uri = '/articles/%s' % record_id
+        self.permission.add_object_permission_principal(record_uri,
+                                                        'read',
+                                                        'fxa:user')
+        self.permission.add_object_permission_principal(record_uri,
+                                                        'write',
+                                                        'fxa:user')
+        self.resource.record_id = record_id
+        self.resource.request.validated = {'data': {}}
+        self.resource.request.path = record_uri
+
+    def test_permissions_are_provided_in_record_get(self):
+        result = self.resource.get()
+        self.assertIn('permissions', result)
+
+    def test_permissions_are_provided_in_record_put(self):
+        result = self.resource.put()
+        self.assertIn('permissions', result)
+
+    def test_permissions_are_provided_in_record_patch(self):
+        result = self.resource.patch()
+        self.assertIn('permissions', result)
+
+    def test_permissions_are_not_provided_in_record_delete(self):
+        result = self.resource.delete()
+        self.assertNotIn('permissions', result)
+
+    def test_permissions_gives_lists_of_principals_per_ace(self):
+        result = self.resource.get()
+        permissions = result['permissions']
+        self.assertEqual(permissions['read'], {'fxa:user'})
+        self.assertEqual(permissions['write'], {'fxa:user'})

--- a/cliquet/tests/resource/test_pagination.py
+++ b/cliquet/tests/resource/test_pagination.py
@@ -33,27 +33,27 @@ class PaginationTest(BaseTest):
         self.last_response.headers = {}
         return queryparams
 
-    def test_return_items(self):
+    def test_return_data(self):
         result = self.resource.collection_get()
-        self.assertEqual(len(result['items']), 20)
+        self.assertEqual(len(result['data']), 20)
 
     def test_handle_limit(self):
         self.resource.request.GET = {'_limit': '10'}
         result = self.resource.collection_get()
-        self.assertEqual(len(result['items']), 10)
+        self.assertEqual(len(result['data']), 10)
 
     def test_handle_forced_limit(self):
         with mock.patch.dict(self.resource.request.registry.settings, [
                 ('cliquet.paginate_by', 10)]):
             result = self.resource.collection_get()
-            self.assertEqual(len(result['items']), 10)
+            self.assertEqual(len(result['data']), 10)
 
     def test_forced_limit_has_precedence_over_provided_limit(self):
         with mock.patch.dict(self.resource.request.registry.settings, [
                 ('cliquet.paginate_by', 5)]):
             self.resource.request.GET = {'_limit': '10'}
             result = self.resource.collection_get()
-            self.assertEqual(len(result['items']), 5)
+            self.assertEqual(len(result['data']), 5)
 
     def test_return_next_page_url_is_given_in_headers(self):
         self.resource.request.GET = {'_limit': '10'}
@@ -72,8 +72,8 @@ class PaginationTest(BaseTest):
         results1 = self.resource.collection_get()
         self._setup_next_page()
         results2 = self.resource.collection_get()
-        results_id1 = set([x['id'] for x in results1['items']])
-        results_id2 = set([x['id'] for x in results2['items']])
+        results_id1 = set([x['id'] for x in results1['data']])
+        results_id2 = set([x['id'] for x in results2['data']])
         self.assertFalse(results_id1.intersection(results_id2))
 
     def test_twice_the_same_next_page(self):
@@ -109,8 +109,8 @@ class PaginationTest(BaseTest):
         results1 = self.resource.collection_get()
         self._setup_next_page()
         results2 = self.resource.collection_get()
-        self.assertEqual(expected_results['items'],
-                         results1['items'] + results2['items'])
+        self.assertEqual(expected_results['data'],
+                         results1['data'] + results2['data'])
 
     def test_handle_multiple_sorting(self):
         self.resource.request.GET = {'_sort': '-status,title', '_limit': '20'}
@@ -119,8 +119,8 @@ class PaginationTest(BaseTest):
         results1 = self.resource.collection_get()
         self._setup_next_page()
         results2 = self.resource.collection_get()
-        self.assertEqual(expected_results['items'],
-                         results1['items'] + results2['items'])
+        self.assertEqual(expected_results['data'],
+                         results1['data'] + results2['data'])
 
     def test_handle_filtering_sorting(self):
         self.resource.request.GET = {'_sort': '-status,title', 'status': '2',
@@ -130,8 +130,8 @@ class PaginationTest(BaseTest):
         results1 = self.resource.collection_get()
         self._setup_next_page()
         results2 = self.resource.collection_get()
-        self.assertEqual(expected_results['items'],
-                         results1['items'] + results2['items'])
+        self.assertEqual(expected_results['data'],
+                         results1['data'] + results2['data'])
 
     def test_handle_sorting_desc(self):
         self.resource.request.GET = {'_sort': 'status,-title', '_limit': '20'}
@@ -140,8 +140,8 @@ class PaginationTest(BaseTest):
         results1 = self.resource.collection_get()
         self._setup_next_page()
         results2 = self.resource.collection_get()
-        self.assertEqual(expected_results['items'],
-                         results1['items'] + results2['items'])
+        self.assertEqual(expected_results['data'],
+                         results1['data'] + results2['data'])
 
     def test_handle_since(self):
         self.resource.request.GET = {'_since': '123', '_limit': '20'}
@@ -150,8 +150,8 @@ class PaginationTest(BaseTest):
         results1 = self.resource.collection_get()
         self._setup_next_page()
         results2 = self.resource.collection_get()
-        self.assertEqual(expected_results['items'],
-                         results1['items'] + results2['items'])
+        self.assertEqual(expected_results['data'],
+                         results1['data'] + results2['data'])
 
     def test_wrong_limit_raise_400(self):
         self.resource.request.GET = {'_since': '123', '_limit': 'toto'}

--- a/cliquet/tests/resource/test_record.py
+++ b/cliquet/tests/resource/test_record.py
@@ -10,7 +10,7 @@ class GetTest(BaseTest):
     def test_get_record_returns_all_fields(self):
         record = self.collection.create_record({'field': 'value'})
         self.resource.record_id = record['id']
-        result = self.resource.get()
+        result = self.resource.get()['data']
         self.assertIn(self.resource.collection.id_field, result)
         self.assertIn(self.resource.collection.modified_field, result)
         self.assertIn('field', result)
@@ -23,21 +23,21 @@ class PutTest(BaseTest):
         self.resource.record_id = self.record['id']
 
     def test_replace_record_returns_updated_fields(self):
-        self.resource.request.validated = {'field': 'new'}
+        self.resource.request.validated = {'data': {'field': 'new'}}
 
-        result = self.resource.put()
+        result = self.resource.put()['data']
         self.assertEqual(self.record['id'], result['id'])
         self.assertNotEqual(self.record['last_modified'],
                             result['last_modified'])
         self.assertNotEqual(self.record['field'], 'new')
 
     def test_cannot_replace_with_different_id(self):
-        self.resource.request.validated = {'id': 'abc'}
+        self.resource.request.validated = {'data': {'id': 'abc'}}
         self.assertRaises(httpexceptions.HTTPBadRequest, self.resource.put)
 
     def test_last_modified_is_overwritten_on_replace(self):
-        self.resource.request.validated = {'last_modified': 123}
-        result = self.resource.put()
+        self.resource.request.validated = {'data': {'last_modified': 123}}
+        result = self.resource.put()['data']
         self.assertNotEqual(result['last_modified'], 123)
 
 
@@ -46,13 +46,13 @@ class DeleteTest(BaseTest):
         record = {'field': 'value'}
         record = self.collection.create_record(record).copy()
         self.resource.record_id = record['id']
-        result = self.resource.delete()
+        result = self.resource.delete()['data']
         self.assertNotEqual(result['last_modified'], record['last_modified'])
 
     def test_delete_record_returns_stripped_record(self):
         record = self.collection.create_record({'field': 'value'})
         self.resource.record_id = record['id']
-        result = self.resource.delete()
+        result = self.resource.delete()['data']
         self.assertEqual(result['id'], record['id'])
         self.assertNotIn('field', result)
         self.assertIn('last_modified', result)
@@ -63,9 +63,9 @@ class PatchTest(BaseTest):
         super(PatchTest, self).setUp()
         self.stored = self.collection.create_record({})
         self.resource.record_id = self.stored['id']
-        self.resource.request.json = {'some': 'change'}
+        self.resource.request.json = {'data': {'some': 'change'}}
         self.resource.mapping.typ.unknown = 'preserve'
-        self.result = self.resource.patch()
+        self.result = self.resource.patch()['data']
 
     def test_modify_record_updates_timestamp(self):
         before = self.stored['last_modified']
@@ -77,47 +77,47 @@ class PatchTest(BaseTest):
         self.assertEquals(self.result['some'], 'change')
 
     def test_record_timestamp_is_not_updated_if_none_for_missing_field(self):
-        self.resource.request.json = {'plop': None}
-        result = self.resource.patch()
+        self.resource.request.json = {'data': {'plop': None}}
+        result = self.resource.patch()['data']
         self.assertEquals(self.result['last_modified'],
                           result['last_modified'])
 
     def test_record_timestamp_is_not_updated_if_no_field_changed(self):
-        self.resource.request.json = {'some': 'change'}
-        result = self.resource.patch()
+        self.resource.request.json = {'data': {'some': 'change'}}
+        result = self.resource.patch()['data']
         self.assertEquals(self.result['last_modified'],
                           result['last_modified'])
 
     def test_collection_timestamp_is_not_updated_if_no_field_changed(self):
-        self.resource.request.json = {'some': 'change'}
+        self.resource.request.json = {'data': {'some': 'change'}}
         self.resource.patch()
         self.resource = BaseResource(self.get_request())
-        self.resource.collection_get()
+        self.resource.collection_get()['data']
         last_modified = self.last_response.headers['Last-Modified']
         self.assertEquals(self.result['last_modified'], int(last_modified))
 
     def test_timestamp_is_not_updated_if_no_change_after_preprocessed(self):
         with mock.patch.object(self.resource, 'process_record') as mocked:
             mocked.return_value = self.result
-            self.resource.request.json = {'some': 'plop'}
-            result = self.resource.patch()
+            self.resource.request.json = {'data': {'some': 'plop'}}
+            result = self.resource.patch()['data']
             self.assertEquals(self.result['last_modified'],
                               result['last_modified'])
 
     def test_returns_changed_fields_among_provided_if_behaviour_is_diff(self):
-        self.resource.request.json = {'unread': True, 'position': 10}
+        self.resource.request.json = {'data': {'unread': True, 'position': 10}}
         self.resource.request.headers['Response-Behavior'] = 'diff'
         with mock.patch.object(self.resource.collection, 'update_record',
                                return_value={'unread': True, 'position': 0}):
-            result = self.resource.patch()
+            result = self.resource.patch()['data']
         self.assertDictEqual(result, {'position': 0})
 
     def test_returns_changed_fields_if_behaviour_is_light(self):
-        self.resource.request.json = {'unread': True, 'position': 10}
+        self.resource.request.json = {'data': {'unread': True, 'position': 10}}
         self.resource.request.headers['Response-Behavior'] = 'light'
         with mock.patch.object(self.resource.collection, 'update_record',
                                return_value={'unread': True, 'position': 0}):
-            result = self.resource.patch()
+            result = self.resource.patch()['data']
         self.assertDictEqual(result, {'unread': True, 'position': 0})
 
 
@@ -126,6 +126,7 @@ class UnknownRecordTest(BaseTest):
         super(UnknownRecordTest, self).setUp()
         self.unknown_id = '1cea99eb-5e3d-44ad-a53a-2fb68473b538'
         self.resource.record_id = self.unknown_id
+        self.resource.request.validated = {'data': {'field': 'new'}}
 
     def test_get_record_unknown_raises_404(self):
         self.assertRaises(httpexceptions.HTTPNotFound, self.resource.get)
@@ -182,11 +183,9 @@ class ReadonlyFieldsTest(BaseTest):
                          'name': 'age'}]})
 
     def test_can_specify_readonly_fields_if_not_changed(self):
-        self.resource.request.json = {
-            'age': self.stored['age'],
-        }
+        self.resource.request.json = {'data': {'age': self.stored['age']}}
         self.resource.patch()  # not raising
 
     def test_cannot_modify_readonly_field(self):
-        self.resource.request.json = {'age': 16}
+        self.resource.request.json = {'data': {'age': 16}}
         self.assertReadonlyError('age')

--- a/cliquet/tests/resource/test_sort.py
+++ b/cliquet/tests/resource/test_sort.py
@@ -26,7 +26,7 @@ class SortingTest(BaseTest):
         self.resource.collection.parent_id = 'alice'
         self.resource.request.GET = {'_sort': 'unread'}
         result = self.resource.collection_get()
-        self.assertEqual(len(result['items']), 0)
+        self.assertEqual(len(result['data']), 0)
 
     def test_sort_on_unknown_attribute_raises_error(self):
         self.patch_known_field.stop()
@@ -55,48 +55,48 @@ class SortingTest(BaseTest):
         self.resource.request.GET = {'_sort': '-last_modified'}
         result = self.resource.collection_get()
         tstamp = self.collection.timestamp()
-        self.assertEqual(result['items'][0]['last_modified'], tstamp)
+        self.assertEqual(result['data'][0]['last_modified'], tstamp)
 
     def test_single_basic_sort_by_attribute(self):
         self.resource.request.GET = {'_sort': 'title'}
         result = self.resource.collection_get()
-        self.assertEqual(len(result['items']), 20)
-        self.assertEqual(result['items'][0]['title'], 'MoFo #00')
-        self.assertEqual(result['items'][-1]['title'], 'MoFo #19')
+        self.assertEqual(len(result['data']), 20)
+        self.assertEqual(result['data'][0]['title'], 'MoFo #00')
+        self.assertEqual(result['data'][-1]['title'], 'MoFo #19')
 
     def test_single_basic_sort_by_attribute_reversed(self):
         self.resource.request.GET = {'_sort': '-title'}
         result = self.resource.collection_get()
-        self.assertEqual(len(result['items']), 20)
-        self.assertEqual(result['items'][0]['title'], 'MoFo #19')
-        self.assertEqual(result['items'][-1]['title'], 'MoFo #00')
+        self.assertEqual(len(result['data']), 20)
+        self.assertEqual(result['data'][0]['title'], 'MoFo #19')
+        self.assertEqual(result['data'][-1]['title'], 'MoFo #00')
 
     def test_multiple_sort(self):
         self.resource.request.GET = {'_sort': 'status,title'}
         result = self.resource.collection_get()
-        self.assertEqual(result['items'][0]['status'], 0)
-        self.assertEqual(result['items'][0]['title'], 'MoFo #00')
-        self.assertEqual(result['items'][1]['status'], 0)
-        self.assertEqual(result['items'][1]['title'], 'MoFo #04')
-        self.assertEqual(result['items'][-2]['status'], 3)
-        self.assertEqual(result['items'][-2]['title'], 'MoFo #15')
-        self.assertEqual(result['items'][-1]['status'], 3)
-        self.assertEqual(result['items'][-1]['title'], 'MoFo #19')
+        self.assertEqual(result['data'][0]['status'], 0)
+        self.assertEqual(result['data'][0]['title'], 'MoFo #00')
+        self.assertEqual(result['data'][1]['status'], 0)
+        self.assertEqual(result['data'][1]['title'], 'MoFo #04')
+        self.assertEqual(result['data'][-2]['status'], 3)
+        self.assertEqual(result['data'][-2]['title'], 'MoFo #15')
+        self.assertEqual(result['data'][-1]['status'], 3)
+        self.assertEqual(result['data'][-1]['title'], 'MoFo #19')
 
     def test_multiple_sort_with_order(self):
         self.resource.request.GET = {'_sort': 'status,-title'}
         result = self.resource.collection_get()
-        self.assertEqual(result['items'][0]['status'], 0)
-        self.assertEqual(result['items'][0]['title'], 'MoFo #16')
-        self.assertEqual(result['items'][1]['status'], 0)
-        self.assertEqual(result['items'][1]['title'], 'MoFo #12')
-        self.assertEqual(result['items'][-2]['status'], 3)
-        self.assertEqual(result['items'][-2]['title'], 'MoFo #07')
-        self.assertEqual(result['items'][-1]['status'], 3)
-        self.assertEqual(result['items'][-1]['title'], 'MoFo #03')
+        self.assertEqual(result['data'][0]['status'], 0)
+        self.assertEqual(result['data'][0]['title'], 'MoFo #16')
+        self.assertEqual(result['data'][1]['status'], 0)
+        self.assertEqual(result['data'][1]['title'], 'MoFo #12')
+        self.assertEqual(result['data'][-2]['status'], 3)
+        self.assertEqual(result['data'][-2]['title'], 'MoFo #07')
+        self.assertEqual(result['data'][-1]['status'], 3)
+        self.assertEqual(result['data'][-1]['title'], 'MoFo #03')
 
     def test_boolean_sort_brings_true_last(self):
         self.resource.request.GET = {'_sort': 'unread'}
         result = self.resource.collection_get()
-        self.assertEqual(result['items'][0]['unread'], False)
-        self.assertEqual(result['items'][-1]['unread'], True)
+        self.assertEqual(result['data'][0]['unread'], False)
+        self.assertEqual(result['data'][-1]['unread'], True)

--- a/cliquet/tests/resource/test_views.py
+++ b/cliquet/tests/resource/test_views.py
@@ -383,7 +383,7 @@ class ConflictErrorsTest(BaseWebTest):
         resp = self.app.post_json(self.collection_url,
                                   body,
                                   headers=self.headers)
-        self.assertEqual(resp.json, {'id': 42})
+        self.assertEqual(resp.json['data'], {'id': 42})
 
     def test_put_returns_409(self):
         body = {'data': MINIMALIST_RECORD}

--- a/cliquet/tests/resource/test_views.py
+++ b/cliquet/tests/resource/test_views.py
@@ -58,11 +58,12 @@ class AuthzAuthnTest(BaseWebTest):
     def test_all_views_require_authentication(self):
         self.app.get(self.collection_url, status=401)
 
-        self.app.post_json(self.collection_url, MINIMALIST_RECORD, status=401)
+        body = {'data': MINIMALIST_RECORD}
+        self.app.post_json(self.collection_url, body, status=401)
 
         url = self.get_item_url('abc')
         self.app.get(url, status=401)
-        self.app.patch_json(url, MINIMALIST_RECORD, status=401)
+        self.app.patch_json(url, body, status=401)
         self.app.delete(url, status=401)
 
 
@@ -108,6 +109,7 @@ class RecordAuthzGrantedTest(AuthzAuthnTest):
         self.app.app.registry.permission.add_principal_to_ace(
             self.collection_url, 'mushroom:create', self.principal)
 
+        body = {'data': MINIMALIST_RECORD}
         resp = self.app.post_json(self.collection_url,
                                   MINIMALIST_RECORD,
                                   headers=self.headers)
@@ -183,33 +185,35 @@ class RecordAuthzDeniedTest(RecordAuthzGrantedTest):
 class InvalidRecordTest(BaseWebTest):
     def setUp(self):
         super(InvalidRecordTest, self).setUp()
+        body = {'data': MINIMALIST_RECORD}
         resp = self.app.post_json(self.collection_url,
-                                  MINIMALIST_RECORD,
+                                  body,
                                   headers=self.headers)
-        self.record = resp.json
+        self.record = resp.json['data']
 
-        self.invalid_record = {'name': 42}
+        self.invalid_record = {'data': {'name': 42}}
 
     def test_invalid_record_returns_json_formatted_error(self):
         resp = self.app.post_json(self.collection_url,
                                   self.invalid_record,
                                   headers=self.headers,
                                   status=400)
+        # XXX: weird resp.json['message']
         self.assertDictEqual(resp.json, {
             'errno': ERRORS.INVALID_PARAMETERS,
-            'message': "42 is not a string: {'name': ''}",  # XXX: weird msg
+            'message': "data.name in body: 42 is not a string: {'name': ''}",
             'code': 400,
             'error': 'Invalid parameters',
             'details': [{'description': "42 is not a string: {'name': ''}",
                          'location': 'body',
-                         'name': 'name'}]})
+                         'name': 'data.name'}]})
 
     def test_empty_body_returns_400(self):
         resp = self.app.post(self.collection_url,
                              '',
                              headers=self.headers,
                              status=400)
-        self.assertEqual(resp.json['message'], 'name is missing')
+        self.assertEqual(resp.json['message'], 'data is missing')
 
     def test_create_invalid_record_returns_400(self):
         self.app.post_json(self.collection_url,
@@ -233,41 +237,45 @@ class InvalidRecordTest(BaseWebTest):
 class IgnoredFieldsTest(BaseWebTest):
     def setUp(self):
         super(IgnoredFieldsTest, self).setUp()
+        body = {'data': MINIMALIST_RECORD}
         resp = self.app.post_json(self.collection_url,
-                                  MINIMALIST_RECORD,
+                                  body,
                                   headers=self.headers)
-        self.record = resp.json
+        self.record = resp.json['data']
 
     def test_id_is_not_validated_and_overwritten(self):
         record = MINIMALIST_RECORD.copy()
         record['id'] = 3.14
+        body = {'data': record}
         resp = self.app.post_json(self.collection_url,
-                                  record,
+                                  body,
                                   headers=self.headers)
-        self.assertNotEqual(resp.json['id'], 3.14)
+        self.assertNotEqual(resp.json['data']['id'], 3.14)
 
     def test_last_modified_is_not_validated_and_overwritten(self):
         record = MINIMALIST_RECORD.copy()
         record['last_modified'] = 'abc'
+        body = {'data': record}
         resp = self.app.post_json(self.collection_url,
-                                  record,
+                                  body,
                                   headers=self.headers)
-        self.assertNotEqual(resp.json['last_modified'], 'abc')
+        self.assertNotEqual(resp.json['data']['last_modified'], 'abc')
 
     def test_modify_works_with_invalid_last_modified(self):
-        body = {'last_modified': 'abc'}
+        body = {'data': {'last_modified': 'abc'}}
         resp = self.app.patch_json(self.get_item_url(),
                                    body,
                                    headers=self.headers)
-        self.assertNotEqual(resp.json['last_modified'], 'abc')
+        self.assertNotEqual(resp.json['data']['last_modified'], 'abc')
 
     def test_replace_works_with_invalid_last_modified(self):
         record = MINIMALIST_RECORD.copy()
         record['last_modified'] = 'abc'
+        body = {'data': record}
         resp = self.app.put_json(self.get_item_url(),
-                                 record,
+                                 body,
                                  headers=self.headers)
-        self.assertNotEqual(resp.json['last_modified'], 'abc')
+        self.assertNotEqual(resp.json['data']['last_modified'], 'abc')
 
 
 class InvalidBodyTest(BaseWebTest):
@@ -277,10 +285,11 @@ class InvalidBodyTest(BaseWebTest):
 
     def setUp(self):
         super(InvalidBodyTest, self).setUp()
+        body = {'data': MINIMALIST_RECORD}
         resp = self.app.post_json(self.collection_url,
-                                  MINIMALIST_RECORD,
+                                  body,
                                   headers=self.headers)
-        self.record = resp.json
+        self.record = resp.json['data']
 
     def test_invalid_body_returns_json_formatted_error(self):
         resp = self.app.post(self.collection_url,
@@ -298,9 +307,9 @@ class InvalidBodyTest(BaseWebTest):
                 {'description': error_msg,
                  'location': 'body',
                  'name': None},
-                {'description': 'name is missing',
+                {'description': 'data is missing',
                  'location': 'body',
-                 'name': 'name'}]})
+                 'name': 'data'}]})
 
     def test_create_invalid_body_returns_400(self):
         self.app.post(self.collection_url,
@@ -348,10 +357,11 @@ class ConflictErrorsTest(BaseWebTest):
     def setUp(self):
         super(ConflictErrorsTest, self).setUp()
 
+        body = {'data': MINIMALIST_RECORD}
         resp = self.app.post_json(self.collection_url,
-                                  MINIMALIST_RECORD,
+                                  body,
                                   headers=self.headers)
-        self.record = resp.json
+        self.record = resp.json['data']
 
         def unicity_failure(*args, **kwargs):
             raise storage_exceptions.UnicityError('city', {'id': 42})
@@ -362,27 +372,30 @@ class ConflictErrorsTest(BaseWebTest):
             patch.start()
 
     def test_post_returns_200_with_existing_record(self):
+        body = {'data': MINIMALIST_RECORD}
         resp = self.app.post_json(self.collection_url,
-                                  MINIMALIST_RECORD,
+                                  body,
                                   headers=self.headers)
         self.assertEqual(resp.json, {'id': 42})
 
     def test_put_returns_409(self):
+        body = {'data': MINIMALIST_RECORD}
         self.app.put_json(self.get_item_url(),
-                          MINIMALIST_RECORD,
+                          body,
                           headers=self.headers,
                           status=409)
 
     def test_patch_returns_409(self):
-        body = {'name': 'Psylo'}
+        body = {'data': {'name': 'Psylo'}}
         self.app.patch_json(self.get_item_url(),
                             body,
                             headers=self.headers,
                             status=409)
 
     def test_409_error_gives_detail_about_field_and_record(self):
+        body = {'data': MINIMALIST_RECORD}
         resp = self.app.put_json(self.get_item_url(),
-                                 MINIMALIST_RECORD,
+                                 body,
                                  headers=self.headers,
                                  status=409)
         self.assertEqual(resp.json['message'],
@@ -400,17 +413,19 @@ class StorageErrorTest(BaseWebTest):
             side_effect=self.error)
 
     def test_backend_errors_are_served_as_503(self):
+        body = {'data': MINIMALIST_RECORD}
         with self.storage_error_patcher:
             self.app.post_json(self.collection_url,
-                               MINIMALIST_RECORD,
+                               body,
                                headers=self.headers,
                                status=503)
 
     def test_backend_errors_original_error_is_logged(self):
+        body = {'data': MINIMALIST_RECORD}
         with mock.patch('cliquet.views.errors.logger.critical') as mocked:
             with self.storage_error_patcher:
                 self.app.post_json(self.collection_url,
-                                   MINIMALIST_RECORD,
+                                   body,
                                    headers=self.headers,
                                    status=503)
                 self.assertTrue(mocked.called)
@@ -423,11 +438,12 @@ class PaginationNextURLTest(BaseWebTest):
 
     def setUp(self):
         super(PaginationNextURLTest, self).setUp()
+        body = {'data': MINIMALIST_RECORD}
         self.app.post_json(self.collection_url,
-                           MINIMALIST_RECORD,
+                           body,
                            headers=self.headers)
         self.app.post_json(self.collection_url,
-                           MINIMALIST_RECORD,
+                           body,
                            headers=self.headers)
 
     def test_next_page_url_has_got_port_number_if_different_than_80(self):

--- a/cliquet/tests/resource/test_views.py
+++ b/cliquet/tests/resource/test_views.py
@@ -215,6 +215,13 @@ class InvalidRecordTest(BaseWebTest):
                              status=400)
         self.assertEqual(resp.json['message'], 'data is missing')
 
+    def test_unknown_attribute_returns_400(self):
+        resp = self.app.post(self.collection_url,
+                             '{"data": {"name": "ML"}, "datta": {}}',
+                             headers=self.headers,
+                             status=400)
+        self.assertEqual(resp.json['message'], 'datta is not allowed')
+
     def test_create_invalid_record_returns_400(self):
         self.app.post_json(self.collection_url,
                            self.invalid_record,

--- a/cliquet/tests/resource/test_views_cors.py
+++ b/cliquet/tests/resource/test_views_cors.py
@@ -11,11 +11,12 @@ class CORSOriginHeadersTest(BaseWebTest):
         super(CORSOriginHeadersTest, self).setUp()
         self.headers['Origin'] = 'notmyidea.org'
 
+        body = {'data': MINIMALIST_RECORD}
         response = self.app.post_json(self.collection_url,
-                                      MINIMALIST_RECORD,
+                                      body,
                                       headers=self.headers,
                                       status=201)
-        self.record = response.json
+        self.record = response.json['data']
 
     def test_present_on_hello(self):
         response = self.app.get('/',
@@ -41,7 +42,7 @@ class CORSOriginHeadersTest(BaseWebTest):
         self.assertIn('Access-Control-Allow-Origin', response.headers)
 
     def test_present_on_invalid_record_update(self):
-        body = {'name': 42}
+        body = {'data': {'name': 42}}
         response = self.app.patch_json(self.get_item_url(),
                                        body,
                                        headers=self.headers,
@@ -49,8 +50,9 @@ class CORSOriginHeadersTest(BaseWebTest):
         self.assertIn('Access-Control-Allow-Origin', response.headers)
 
     def test_present_on_successful_creation(self):
+        body = {'data': MINIMALIST_RECORD}
         response = self.app.post_json(self.collection_url,
-                                      MINIMALIST_RECORD,
+                                      body,
                                       headers=self.headers,
                                       status=201)
         self.assertIn('Access-Control-Allow-Origin', response.headers)
@@ -67,7 +69,7 @@ class CORSOriginHeadersTest(BaseWebTest):
         with mock.patch('cliquet.tests.testapp.views.'
                         'MushroomSchema.is_readonly',
                         return_value=True):
-            body = {'name': 'Amanite'}
+            body = {'data': {'name': 'Amanite'}}
             response = self.app.patch_json(self.get_item_url(),
                                            body,
                                            headers=self.headers,
@@ -77,8 +79,9 @@ class CORSOriginHeadersTest(BaseWebTest):
 
     def test_present_on_unauthorized(self):
         self.headers.pop('Authorization', None)
+        body = {'data': MINIMALIST_RECORD}
         response = self.app.post_json(self.collection_url,
-                                      MINIMALIST_RECORD,
+                                      body,
                                       headers=self.headers,
                                       status=401)
         self.assertIn('Access-Control-Allow-Origin', response.headers)
@@ -110,14 +113,16 @@ class CORSExposeHeadersTest(BaseWebTest):
             'Alert', 'Backoff', 'Retry-After'])
 
     def test_record_get_exposes_only_used_headers(self):
+        body = {'data': MINIMALIST_RECORD}
         resp = self.app.post_json(self.collection_url,
-                                  MINIMALIST_RECORD,
+                                  body,
                                   headers=self.headers,
                                   status=201)
-        record_url = self.get_item_url(resp.json['id'])
+        record_url = self.get_item_url(resp.json['data']['id'])
         self.assert_expose_headers('GET', record_url, [
             'Alert', 'Backoff', 'Retry-After', 'Last-Modified'])
 
     def test_record_post_exposes_only_minimal_set_of_headers(self):
+        body = {'data': MINIMALIST_RECORD}
         self.assert_expose_headers('POST_JSON', '/mushrooms', [
-            'Alert', 'Backoff', 'Retry-After'], body=MINIMALIST_RECORD)
+            'Alert', 'Backoff', 'Retry-After'], body=body)

--- a/cliquet/tests/resource/test_viewset.py
+++ b/cliquet/tests/resource/test_viewset.py
@@ -63,7 +63,8 @@ class ViewSetTest(unittest.TestCase):
         )
         resource = mock.MagicMock(mapping=colander.SchemaNode(colander.Int()))
         arguments = viewset.collection_arguments(resource, 'GET')
-        self.assertEquals(arguments['schema'], resource.mapping)
+        schema = arguments['schema']
+        self.assertEquals(schema.children[0], resource.mapping)
 
     def test_schema_is_added_when_uppercase_method_matches(self):
         viewset = ViewSet(
@@ -71,7 +72,8 @@ class ViewSetTest(unittest.TestCase):
         )
         resource = mock.MagicMock(mapping=colander.SchemaNode(colander.Int()))
         arguments = viewset.collection_arguments(resource, 'get')
-        self.assertEquals(arguments['schema'], resource.mapping)
+        schema = arguments['schema']
+        self.assertEquals(schema.children[0], resource.mapping)
 
     @mock.patch('cliquet.resource.colander')
     def test_a_default_schema_is_added_when_method_doesnt_match(self, mocked):

--- a/cliquet/tests/test_logging.py
+++ b/cliquet/tests/test_logging.py
@@ -279,9 +279,9 @@ class ResourceInfoTest(BaseWebTest, unittest.TestCase):
                          int(r.headers['Last-Modified']))
 
     def test_result_size_and_limit_are_bound(self):
-        self.app.post_json('/mushrooms', {'name': 'a'}, headers=self.headers)
-        self.app.post_json('/mushrooms', {'name': 'b'}, headers=self.headers)
-        self.app.post_json('/mushrooms', {'name': 'c'}, headers=self.headers)
+        for name in ['a', 'b', 'c']:
+            body = {'data': {'name': name}}
+            self.app.post_json('/mushrooms', body, headers=self.headers)
 
         self.app.get('/mushrooms?_limit=5', headers=self.headers)
         event_dict = logger_context()

--- a/cliquet/tests/test_schema.py
+++ b/cliquet/tests/test_schema.py
@@ -60,3 +60,43 @@ class ResourceSchemaTest(unittest.TestCase):
         schema_instance = PreserveSchema()
         deserialized = schema_instance.deserialize({'foo': 'bar'})
         self.assertNotIn('foo', deserialized)
+
+
+class PermissionsSchemaTest(unittest.TestCase):
+
+    def setUp(self):
+        self.schema = schema.PermissionsSchema()
+
+    def test_works_with_any_permission_name_by_default(self):
+        perms = {'can_cook': ['mat']}
+        deserialized = self.schema.deserialize(perms)
+        self.assertEqual(deserialized, perms)
+
+    def test_works_with_empty_mapping(self):
+        perms = {}
+        deserialized = self.schema.deserialize(perms)
+        self.assertEqual(deserialized, perms)
+
+    def test_works_with_empty_list_of_principals(self):
+        perms = {'can_cook': []}
+        deserialized = self.schema.deserialize(perms)
+        self.assertEqual(deserialized, perms)
+
+    def test_raises_invalid_if_permission_is_unknown(self):
+        self.schema.known_perms = ('can_sleep',)
+        perms = {'can_work': ['mat']}
+        self.assertRaises(colander.Invalid,
+                          self.schema.deserialize,
+                          perms)
+
+    def test_raises_invalid_if_not_list(self):
+        perms = {'can_cook': 3.14}
+        self.assertRaises(colander.Invalid,
+                          self.schema.deserialize,
+                          perms)
+
+    def test_raises_invalid_if_not_list_of_strings(self):
+        perms = {'can_cook': ['pi', 3.14]}
+        self.assertRaises(colander.Invalid,
+                          self.schema.deserialize,
+                          perms)

--- a/cliquet/tests/testapp/views.py
+++ b/cliquet/tests/testapp/views.py
@@ -10,3 +10,8 @@ class MushroomSchema(resource.ResourceSchema):
 @resource.register(factory=authorization.RouteFactory)
 class Mushroom(resource.BaseResource):
     mapping = MushroomSchema()
+
+
+@resource.register(factory=authorization.RouteFactory)
+class Toadstool(resource.ProtectedResource):
+    mapping = MushroomSchema()

--- a/docs/api/resource.rst
+++ b/docs/api/resource.rst
@@ -13,7 +13,7 @@ Returns all records of the current user for this collection.
 
 The returned value is a JSON mapping containing:
 
-- ``items``: the list of records, with exhaustive attributes
+- ``data``: the list of records, with exhaustive fields
 
 A ``Total-Records`` response header indicates the total number of records
 of the collection.
@@ -47,7 +47,7 @@ It is likely to be used by consumer to provide ``If-Modified-Since`` or
     Total-Records: 2
 
     {
-        "items": [
+        "data": [
             {
                 "id": "dc86afa9-a839-4ce1-ae02-3d538b75496f",
                 "last_modified": 1430222877724,
@@ -202,10 +202,14 @@ POST /{collection}
 
 **Requires authentication**
 
-Used to create a record in the collection. The POST body is a JSON
-mapping containing the values of the resource schema fields.
+Used to create a record in the collection. The POST body is a JSON mapping
+containing:
 
-The POST response body is the newly created record, if all posted values are valid.
+- ``data``: the values of the resource schema fields
+
+The POST response body is a JSON mapping containing:
+
+- ``data``: the newly created record, if all posted values are valid.
 
 If the request header ``If-Unmodified-Since`` is provided, and if the record has
 changed meanwhile, a ``412 Precondition failed`` error is returned.
@@ -222,8 +226,10 @@ changed meanwhile, a ``412 Precondition failed`` error is returned.
     Host: localhost:8000
 
     {
-        "title": "Wikipedia FR",
-        "url": "http://fr.wikipedia.org"
+        "data": {
+            "title": "Wikipedia FR",
+            "url": "http://fr.wikipedia.org"
+        }
     }
 
 **Response**:
@@ -238,10 +244,12 @@ changed meanwhile, a ``412 Precondition failed`` error is returned.
     Date: Tue, 28 Apr 2015 12:35:02 GMT
 
     {
-        "id": "cd30c031-c208-4fb9-ad65-1582d2a7ad5e",
-        "last_modified": 1430224502529,
-        "title": "Wikipedia FR",
-        "url": "http://fr.wikipedia.org"
+        "data": {
+            "id": "cd30c031-c208-4fb9-ad65-1582d2a7ad5e",
+            "last_modified": 1430224502529,
+            "title": "Wikipedia FR",
+            "url": "http://fr.wikipedia.org"
+        }
     }
 
 
@@ -291,8 +299,9 @@ DELETE /{collection}
 
 Delete multiple records. **Disabled by default**, see :ref:`configuration`.
 
-The DELETE response is a JSON mapping with an ``items`` attribute, returning
-the list of records that were deleted.
+The DELETE response is a JSON mapping containing:
+
+- ``data``: list of records that were deleted, without schema fields.
 
 It supports the same filtering capabilities as GET.
 
@@ -321,7 +330,7 @@ has changed meanwhile, a ``412 Precondition failed`` error is returned.
     Date: Tue, 28 Apr 2015 12:38:36 GMT
 
     {
-        "items": [
+        "data": [
             {
                 "deleted": true,
                 "id": "cd30c031-c208-4fb9-ad65-1582d2a7ad5e",
@@ -349,7 +358,10 @@ GET /{collection}/<id>
 
 **Requires authentication**
 
-Returns a specific record by its id.
+Returns a specific record by its id. The GET response body is a JSON mapping
+containing:
+
+- ``data``: the record with exhaustive schema fields.
 
 For convenience and consistency, a header ``Last-Modified`` will also repeat the
 value of the ``last_modified`` field.
@@ -379,10 +391,12 @@ changed meanwhile, a ``304 Not Modified`` is returned.
     Last-Modified: 1430224945242
 
     {
-        "id": "d10405bf-8161-46a1-ac93-a1893d160e62",
-        "last_modified": 1430224945242,
-        "title": "No backend",
-        "url": "http://nobackend.org"
+        "data": {
+            "id": "d10405bf-8161-46a1-ac93-a1893d160e62",
+            "last_modified": 1430224945242,
+            "title": "No backend",
+            "url": "http://nobackend.org"
+        }
     }
 
 
@@ -401,7 +415,9 @@ DELETE /{collection}/<id>
 
 Delete a specific record by its id.
 
-The DELETE response is the record that was deleted.
+The DELETE response is the record that was deleted. The DELETE response is a JSON mapping containing:
+
+- ``data``: the record that was deleted, without schema fields.
 
 If the record is missing (or already deleted), a ``404 Not Found`` is returned.
 The consumer might decide to ignore it.
@@ -426,8 +442,13 @@ PUT /{collection}/<id>
 
 **Requires authentication**
 
-Create or replace a record with its id. The PUT body is a JSON
-mapping validating the resource schema fields.
+Create or replace a record with its id. The PUT body is a JSON mapping containing:
+
+- ``data``: the values of the resource schema fields
+
+The PUT response body is a JSON mapping containing:
+
+- ``data``: the newly created/updated record, if all posted values are valid.
 
 Validation and conflicts behaviour is similar to creating records (``POST``).
 
@@ -446,8 +467,10 @@ changed meanwhile, a ``412 Precondition failed`` error is returned.
     Host: localhost:8000
 
     {
-        "title": "Static apps",
-        "url": "http://www.staticapps.org"
+        "data": {
+            "title": "Static apps",
+            "url": "http://www.staticapps.org"
+        }
     }
 
 **Response**:
@@ -462,10 +485,12 @@ changed meanwhile, a ``412 Precondition failed`` error is returned.
     Date: Tue, 28 Apr 2015 12:46:36 GMT
 
     {
-        "id": "d10405bf-8161-46a1-ac93-a1893d160e62",
-        "last_modified": 1430225196396,
-        "title": "Static apps",
-        "url": "http://www.staticapps.org"
+        "data": {
+            "id": "d10405bf-8161-46a1-ac93-a1893d160e62",
+            "last_modified": 1430225196396,
+            "title": "Static apps",
+            "url": "http://www.staticapps.org"
+        }
     }
 
 
@@ -484,17 +509,18 @@ PATCH /{collection}/<id>
 
 **Requires authentication**
 
-Modify a specific record by its id. The PATCH body is a JSON
-mapping containing a subset of the resource schema fields.
+Modify a specific record by its id. The PATCH body is a JSON mapping containing:
 
-The PATCH response is the modified record (*full*).
+- ``data``: a subset of the resource schema fields.
+
+The PATCH response body is a JSON mapping containing:
+
+- ``data``: the modified record (*full by default*)
 
 If a request header ``Response-Behavior`` is set to ``light``,
 only the fields whose value was changed are returned. If set to
 ``diff``, only the fields whose value became different than
 the one provided are returned.
-
-
 
 
 **Request**:
@@ -508,7 +534,9 @@ the one provided are returned.
     Host: localhost:8000
 
     {
-        "title": "No Backend"
+        "data": {
+            "title": "No Backend"
+        }
     }
 
 **Response**:
@@ -523,10 +551,12 @@ the one provided are returned.
     Date: Tue, 28 Apr 2015 12:46:36 GMT
 
     {
-        "id": "d10405bf-8161-46a1-ac93-a1893d160e62",
-        "last_modified": 1430225196396,
-        "title": "No Backend",
-        "url": "http://nobackend.org"
+        "data": {
+            "id": "d10405bf-8161-46a1-ac93-a1893d160e62",
+            "last_modified": 1430225196396,
+            "title": "No Backend",
+            "url": "http://nobackend.org"
+        }
     }
 
 


### PR DESCRIPTION
Based on top of #287.

* [x] Provide current permissions
* [x] Define permission Colander schema and validate permissions modifications
* [x] Handle changes of permissions on records
* ~~[ ] PUT and PATCH on collection~~
* [x] Functional tests (via pyramid stack)

This aims to implement what was done by @Natim here : https://github.com/mozilla-services/kinto/pull/37

Note:
>  Verification of permissions is being done in another PR by @ametaireau 
