### PR TITLE
Raise 400 if specified permission name is invalid

### DIFF
--- a/cliquet/resource.py
+++ b/cliquet/resource.py
@@ -100,7 +100,9 @@ class ViewSet(object):
 
         class RecordPayload(colander.MappingSchema):
             data = resource.mapping
-            permissions = PermissionsSchema(missing=colander.drop)
+            permissions = PermissionsSchema(
+                missing=colander.drop,
+                permissions=getattr(resource, 'permissions', tuple()))
 
             def schema_type(self, **kw):
                 return colander.Mapping(unknown='raise')

--- a/cliquet/resource.py
+++ b/cliquet/resource.py
@@ -98,11 +98,14 @@ class ViewSet(object):
             # Simply validate that posted body is a mapping.
             return colander.MappingSchema(unknown='preserve')
 
+        # XXX: https://github.com/mozilla-services/cliquet/issues/322
+        resource_permissions = getattr(resource, 'permissions', tuple())
+
         class RecordPayload(colander.MappingSchema):
             data = resource.mapping
             permissions = PermissionsSchema(
                 missing=colander.drop,
-                permissions=getattr(resource, 'permissions', tuple()))
+                permissions=resource_permissions)
 
             def schema_type(self, **kw):
                 return colander.Mapping(unknown='raise')

--- a/cliquet/schema.py
+++ b/cliquet/schema.py
@@ -82,7 +82,9 @@ class PermissionsSchema(colander.SchemaNode):
         }
 
     """
-    known_perms = tuple()
+    def __init__(self, *args, **kwargs):
+        self.known_perms = kwargs.pop('permissions', tuple())
+        super(PermissionsSchema, self).__init__(*args, **kwargs)
 
     def schema_type(self, **kw):
         return colander.Mapping(unknown='preserve')

--- a/cliquet/tests/resource/test_views.py
+++ b/cliquet/tests/resource/test_views.py
@@ -88,6 +88,24 @@ class ProtectedResourcePermissionTest(AuthzAuthnTest):
         resp = self.app.put_json(object_uri, body, headers=self.headers)
         self.assertEqual(resp.json['permissions']['read'], ['group:readers'])
 
+    def test_unknown_permissions_are_not_accepted(self):
+        self.maxDiff = None
+        body = {'data': MINIMALIST_RECORD,
+                'permissions': {'read': ['group:readers'],
+                                'unknown': ['jacques']}}
+        resp = self.app.post_json(self.collection_url, body,
+                                  headers=self.headers, status=400)
+        self.assertDictEqual(resp.json, {
+            u'errno': ERRORS.INVALID_PARAMETERS,
+            u'message': u'permissions in body: "unknown" '
+                        u'is not one of read, write',
+            u'code': 400,
+            u'error': u'Invalid parameters',
+            u'details': [{u'description': u'"unknown" is not one '
+                                          u'of read, write',
+                          u'location': u'body',
+                          u'name': u'permissions'}]})
+
 
 class CollectionAuthzGrantedTest(AuthzAuthnTest):
     def test_collection_get_is_granted_when_authorized(self):

--- a/cliquet/tests/resource/test_views.py
+++ b/cliquet/tests/resource/test_views.py
@@ -95,16 +95,9 @@ class ProtectedResourcePermissionTest(AuthzAuthnTest):
                                 'unknown': ['jacques']}}
         resp = self.app.post_json(self.collection_url, body,
                                   headers=self.headers, status=400)
-        self.assertDictEqual(resp.json, {
-            u'errno': ERRORS.INVALID_PARAMETERS,
-            u'message': u'permissions in body: "unknown" '
-                        u'is not one of read, write',
-            u'code': 400,
-            u'error': u'Invalid parameters',
-            u'details': [{u'description': u'"unknown" is not one '
-                                          u'of read, write',
-                          u'location': u'body',
-                          u'name': u'permissions'}]})
+        self.assertEqual(
+            resp.json['message'],
+            'permissions in body: "unknown" is not one of read, write')
 
 
 class CollectionAuthzGrantedTest(AuthzAuthnTest):


### PR DESCRIPTION
Currently the ``PermissionSchema`` is able to raise invalid errors if its ``known_perms`` tuple is set:

* https://github.com/mozilla-services/cliquet/blob/2.0.dev4/cliquet/tests/test_schema.py#L85-L90

However this tuple is not set when instanciated:

* https://github.com/mozilla-services/cliquet/blob/2.0.dev4/cliquet/resource.py#L103

The list of available permissions for a resource is only used to delete/replace existing permission from the permissio backend:

* https://github.com/mozilla-services/cliquet/blob/2.0.dev4/cliquet/resource.py#L1038

We should plug the two together !