### PR TITLE
Add support for PyPy

### DIFF
--- a/cliquet/storage/postgresql/__init__.py
+++ b/cliquet/storage/postgresql/__init__.py
@@ -3,7 +3,7 @@ import os
 import warnings
 from collections import defaultdict
 
-import psycopg2
+from cliquet.utils import psycopg2
 import psycopg2.extras
 import psycopg2.pool
 import six

--- a/cliquet/tests/test_cache.py
+++ b/cliquet/tests/test_cache.py
@@ -1,9 +1,9 @@
 import mock
 import time
 
-import psycopg2
 import redis
 
+from cliquet.utils import psycopg2
 from cliquet.storage import exceptions
 from cliquet.cache import (CacheBase, postgresql as postgresql_backend,
                            redis as redis_backend, memory as memory_backend)

--- a/cliquet/tests/test_permission.py
+++ b/cliquet/tests/test_permission.py
@@ -1,8 +1,8 @@
 import mock
 
-import psycopg2
 import redis
 
+from cliquet.utils import psycopg2
 from cliquet.storage import exceptions
 from cliquet.permission import (PermissionBase, redis as redis_backend,
                                 memory as memory_backend,

--- a/cliquet/tests/test_storage.py
+++ b/cliquet/tests/test_storage.py
@@ -1,9 +1,9 @@
 import time
 
 import mock
-import psycopg2
 import redis
 
+from cliquet.utils import psycopg2
 from cliquet import utils
 from cliquet.storage import (
     exceptions, Filter, generators, memory,

--- a/cliquet/utils.py
+++ b/cliquet/utils.py
@@ -8,16 +8,16 @@ from base64 import b64decode, b64encode
 from binascii import hexlify
 
 # ujson is not installable with pypy
-try:
+try:  # pragma: no cover
     import ujson as json  # NOQA
-except ImportError:
+except ImportError:  # pragma: no cover
     import json  # NOQA
 
 # psycopg2cffi is installed under pypy, instead of psycopg2
 # pragma: no cover
-try:
+try:  # pragma: no cover
     import psycopg2  # NOQA
-except ImportError:
+except ImportError:  # pragma: no cover
     from psycopg2cffi import compat
     compat.register()
     import psycopg2  # NOQA

--- a/cliquet/utils.py
+++ b/cliquet/utils.py
@@ -8,14 +8,13 @@ from base64 import b64decode, b64encode
 from binascii import hexlify
 
 # ujson is not installable with pypy
-try:  # pragma: no cover
+try:
     import ujson as json  # NOQA
 except ImportError:  # pragma: no cover
     import json  # NOQA
 
 # psycopg2cffi is installed under pypy, instead of psycopg2
-# pragma: no cover
-try:  # pragma: no cover
+try:
     import psycopg2  # NOQA
 except ImportError:  # pragma: no cover
     from psycopg2cffi import compat

--- a/cliquet/utils.py
+++ b/cliquet/utils.py
@@ -7,7 +7,11 @@ import time
 from base64 import b64decode, b64encode
 from binascii import hexlify
 
-import ujson as json  # NOQA
+# ujson is not installable with pypy
+try:
+    import ujson as json  # NOQA
+except ImportError:
+    import json
 from cornice import cors
 from colander import null
 

--- a/cliquet/utils.py
+++ b/cliquet/utils.py
@@ -12,6 +12,16 @@ try:
     import ujson as json  # NOQA
 except ImportError:
     import json
+
+# psycopg2cffi is installed under pypy, instead of psycopg2
+# pragma: no cover
+try:
+    import psycopg2
+except ImportError:
+    from psycopg2cffi import compat
+    compat.register()
+    import psycopg2
+
 from cornice import cors
 from colander import null
 

--- a/cliquet/utils.py
+++ b/cliquet/utils.py
@@ -11,16 +11,16 @@ from binascii import hexlify
 try:
     import ujson as json  # NOQA
 except ImportError:
-    import json
+    import json  # NOQA
 
 # psycopg2cffi is installed under pypy, instead of psycopg2
 # pragma: no cover
 try:
-    import psycopg2
+    import psycopg2  # NOQA
 except ImportError:
     from psycopg2cffi import compat
     compat.register()
-    import psycopg2
+    import psycopg2  # NOQA
 
 from cornice import cors
 from colander import null

--- a/docs/reference/installation.rst
+++ b/docs/reference/installation.rst
@@ -40,7 +40,7 @@ For *PostgreSQL* and *monitoring* support:
     When installing cliquet with postgresql support in a virtualenv using the
     `PyPy <http://pypy.org/>`_ interpreter, the
     `psycopg2cffi <https://github.com/chtd/psycopg2cffi>`_ PostgreSQL database
-    adapter will be installed, instead of the traditionnal
+    adapter will be installed, instead of the traditional
     `psycopg2 <https://pythonhosted.org/psycopg2/>`_, as it provides significant
     `performance improvements
     <http://chtd.ru/blog/bystraya-rabota-s-postgres-pod-pypy/?lang=en>`_.

--- a/docs/reference/installation.rst
+++ b/docs/reference/installation.rst
@@ -12,6 +12,12 @@ other backends like « in-memory » or `PostgreSQL <http://postgresql.org/>`_
 can be enabled afterwards.
 
 
+Supported Python versions
+=========================
+
+Cliquet supports Python 2.7, Python 3.4 and PyPy.
+
+
 Distribute & Pip
 ================
 
@@ -27,6 +33,17 @@ For *PostgreSQL* and *monitoring* support:
 ::
 
     pip install cliquet[postgresql,monitoring]
+
+
+.. note::
+
+    When installing cliquet with postgresql support in a virtualenv using the
+    `PyPy <http://pypy.org/>`_ interpreter, the
+    `psycopg2cffi <https://github.com/chtd/psycopg2cffi>`_ PostgreSQL database
+    adapter will be installed, instead of the traditionnal
+    `psycopg2 <https://pythonhosted.org/psycopg2/>`_, as it provides significant
+    `performance improvements
+    <http://chtd.ru/blog/bystraya-rabota-s-postgres-pod-pypy/?lang=en>`_.
 
 
 If everything is under control *python*-wise, jump to the next chapter.

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import sys
 import codecs
 import os
 from setuptools import setup, find_packages
@@ -14,6 +15,7 @@ with codecs.open(os.path.join(here, 'CONTRIBUTORS.rst'),
                  encoding='utf-8') as f:
     CONTRIBUTORS = f.read()
 
+installed_with_pypy = sys.subversion[0] == 'PyPy'
 
 REQUIREMENTS = [
     'colander',
@@ -24,8 +26,11 @@ REQUIREMENTS = [
     'requests',
     'six',
     'structlog',
-    'ujson',
 ]
+
+# ujson is not pypy compliant, as it uses the CPython C API
+if not installed_with_pypy:
+    REQUIREMENTS.append('ujson')
 
 DEPENDENCY_LINKS = [
 ]

--- a/setup.py
+++ b/setup.py
@@ -28,15 +28,20 @@ REQUIREMENTS = [
     'structlog',
 ]
 
-# ujson is not pypy compliant, as it uses the CPython C API
 if not installed_with_pypy:
+    # ujson is not pypy compliant, as it uses the CPython C API
     REQUIREMENTS.append('ujson')
+    # We install psycopg2cffi instead of psycopg2 when dealing with pypy
+    # Note: JSONB support landed in psycopg2cffi 2.7.0
+    POSTGRESQL_REQUIRES = [
+        'psycopg2cffi>2.7.0',
+    ]
+else:
+    POSTGRESQL_REQUIRES = [
+        'psycopg2>2.5',
+    ]
 
 DEPENDENCY_LINKS = [
-]
-
-POSTGRESQL_REQUIRES = [
-    'psycopg2>2.5',
 ]
 
 MONITORING_REQUIRES = [

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ if not installed_with_pypy:
     # ujson is not pypy compliant, as it uses the CPython C API
     REQUIREMENTS.append('ujson')
     # We install psycopg2cffi instead of psycopg2 when dealing with pypy
-    # Note: JSONB support landed in psycopg2cffi 2.7.0
+    # Note: JSONB support landed after psycopg2cffi 2.7.0
     POSTGRESQL_REQUIRES = [
         'psycopg2cffi>2.7.0',
     ]

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-import sys
+import platform
 import codecs
 import os
 from setuptools import setup, find_packages
@@ -15,7 +15,7 @@ with codecs.open(os.path.join(here, 'CONTRIBUTORS.rst'),
                  encoding='utf-8') as f:
     CONTRIBUTORS = f.read()
 
-installed_with_pypy = sys.subversion[0] == 'PyPy'
+installed_with_pypy = platform.python_implementation() == 'PyPy'
 
 REQUIREMENTS = [
     'colander',

--- a/setup.py
+++ b/setup.py
@@ -28,15 +28,15 @@ REQUIREMENTS = [
     'structlog',
 ]
 
-if not installed_with_pypy:
-    # ujson is not pypy compliant, as it uses the CPython C API
-    REQUIREMENTS.append('ujson')
+if installed_with_pypy:
     # We install psycopg2cffi instead of psycopg2 when dealing with pypy
     # Note: JSONB support landed after psycopg2cffi 2.7.0
     POSTGRESQL_REQUIRES = [
         'psycopg2cffi>2.7.0',
     ]
 else:
+    # ujson is not pypy compliant, as it uses the CPython C API
+    REQUIREMENTS.append('ujson')
     POSTGRESQL_REQUIRES = [
         'psycopg2>2.5',
     ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,flake8
+envlist = py27,py34,pypy,flake8
 
 [testenv]
 commands =
@@ -24,6 +24,18 @@ deps =
     mock
     nose
     psycopg2
+    raven
+    statsd
+    webtest
+    newrelic
+    werkzeug
+
+[testenv:pypy]
+deps =
+    coverage
+    mock
+    nose
+    psycopg2cffi
     raven
     statsd
     webtest


### PR DESCRIPTION
Cliquet now supports PyPy, by:

* using ``json`` instead of ``ujson`` (with PyPy only), because ``usjon`` is written in C and uses the CPython C API
* using ``psycopg2cffi`` instead of ``psycopg2`` (with PyPy only)

Warning: this is still a work in progress.
- [x] needs JSONB support in ``psycopg2cffi`` (see https://github.com/chtd/psycopg2cffi/issues/36), or a way to handle deserializing JSONB fields
- [x] a mention of pypy support in the documenation