### PR TITLE
Prefix userid outside authn policies (fixes #299)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,10 @@ This document describes changes between each past release.
 2.1.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+**New features**
+
+- Cliquet does not require authentication policies to prefix
+  user ids anymore (fixes #299).
 
 
 2.0.0 (2015-06-16)

--- a/cliquet/authentication.py
+++ b/cliquet/authentication.py
@@ -29,4 +29,4 @@ class BasicAuthAuthenticationPolicy(base_auth.BasicAuthAuthenticationPolicy):
             hmac_secret = settings['cliquet.userid_hmac_secret']
             credentials = '%s:%s' % credentials
             userid = utils.hmac_digest(hmac_secret, credentials)
-            return "basicauth_%s" % userid
+            return userid

--- a/cliquet/authorization.py
+++ b/cliquet/authorization.py
@@ -19,6 +19,9 @@ class AuthorizationPolicy(object):
     get_bound_permissions = None
 
     def permits(self, context, principals, permission):
+        # User id prefixed with authentication policy type.
+        principals.insert(0, context.prefixed_userid)
+
         if permission == DYNAMIC:
             permission = context.required_permission
 
@@ -96,6 +99,13 @@ class RouteFactory(object):
         self.required_permission = permission
         self.resource_name = resource_name
         self.check_permission = check_permission
+
+        prefixed_userid = None
+        if request.authenticated_userid:
+            authn_type = request.authn_type.lower()
+            user_id = request.authenticated_userid
+            prefixed_userid = '%s_%s' % (authn_type, user_id)
+        self.prefixed_userid = prefixed_userid
 
 
 def get_object_id(object_uri):

--- a/cliquet/initialization.py
+++ b/cliquet/initialization.py
@@ -80,11 +80,11 @@ def setup_authentication(config):
     # By default, permissions are handled dynamically.
     config.set_default_permission(authorization.DYNAMIC)
 
-    # Track policy for logging.
+    # Track policy used, for prefixing user_id and for logging.
     def on_policy_selected(event):
         value = event.policy.__class__.__name__
-        value = value.replace('Authentication', '').replace('Policy', '')
-        event.request.authn_type = value
+        authn_type = value.replace('Authentication', '').replace('Policy', '')
+        event.request.authn_type = authn_type
 
     config.add_subscriber(on_policy_selected, MultiAuthPolicySelected)
 

--- a/cliquet/resource.py
+++ b/cliquet/resource.py
@@ -255,11 +255,10 @@ class BaseResource(object):
     mapping = ResourceSchema()
     """Schema to validate records."""
 
-    def __init__(self, request, context=None):
-
+    def __init__(self, request, context):
         # Collections are isolated by user.
-        parent_id = (context.prefixed_userid if context else
-                     request.authenticated_userid)
+        parent_id = context.prefixed_userid
+
         # Authentication to storage is transmitted as is (cf. cloud_storage).
         auth = request.headers.get('Authorization')
 

--- a/cliquet/resource.py
+++ b/cliquet/resource.py
@@ -258,7 +258,8 @@ class BaseResource(object):
     def __init__(self, request, context=None):
 
         # Collections are isolated by user.
-        parent_id = request.authenticated_userid
+        parent_id = (context.prefixed_userid if context else
+                     request.authenticated_userid)
         # Authentication to storage is transmitted as is (cf. cloud_storage).
         auth = request.headers.get('Authorization')
 
@@ -1009,7 +1010,7 @@ class ProtectedResource(BaseResource):
 
         if add_write_perm:
             write_principals = permissions.setdefault('write', [])
-            user_principal = self.request.authenticated_userid
+            user_principal = self.context.prefixed_userid
             if user_principal not in write_principals:
                 write_principals.insert(0, user_principal)
 

--- a/cliquet/tests/resource/__init__.py
+++ b/cliquet/tests/resource/__init__.py
@@ -11,9 +11,8 @@ class BaseTest(unittest.TestCase):
 
     def setUp(self):
         self.storage = memory.Memory()
-        request = self.get_request()
-        self.resource = self.resource_class(request=request,
-                                            context=RouteFactory(request))
+        self.resource = self.resource_class(request=self.get_request(),
+                                            context=self.get_context())
         self.collection = self.resource.collection
         self.patch_known_field = mock.patch.object(self.resource,
                                                    'is_known_field')
@@ -25,6 +24,9 @@ class BaseTest(unittest.TestCase):
         request = DummyRequest(method='GET')
         request.registry.storage = self.storage
         return request
+
+    def get_context(self):
+        return RouteFactory(self.get_request())
 
     @property
     def last_response(self):

--- a/cliquet/tests/resource/__init__.py
+++ b/cliquet/tests/resource/__init__.py
@@ -1,5 +1,6 @@
 import mock
 
+from cliquet.authorization import RouteFactory
 from cliquet.storage import memory
 from cliquet.tests.support import unittest, DummyRequest
 from cliquet.resource import BaseResource
@@ -10,7 +11,9 @@ class BaseTest(unittest.TestCase):
 
     def setUp(self):
         self.storage = memory.Memory()
-        self.resource = self.resource_class(self.get_request())
+        request = self.get_request()
+        self.resource = self.resource_class(request=request,
+                                            context=RouteFactory(request))
         self.collection = self.resource.collection
         self.patch_known_field = mock.patch.object(self.resource,
                                                    'is_known_field')
@@ -19,7 +22,7 @@ class BaseTest(unittest.TestCase):
         mock.patch.stopall()
 
     def get_request(self):
-        request = DummyRequest()
+        request = DummyRequest(method='GET')
         request.registry.storage = self.storage
         return request
 

--- a/cliquet/tests/resource/test_collection.py
+++ b/cliquet/tests/resource/test_collection.py
@@ -71,10 +71,10 @@ class IsolatedCollectionsTest(BaseTest):
         self.stored = self.collection.create_record({}, parent_id='bob')
         self.resource.record_id = self.stored['id']
 
-    def get_request(self):
-        request = super(IsolatedCollectionsTest, self).get_request()
-        request.authenticated_userid = 'alice'
-        return request
+    def get_context(self):
+        context = super(IsolatedCollectionsTest, self).get_context()
+        context.prefixed_userid = 'alice'
+        return context
 
     def test_list_is_filtered_by_user(self):
         resp = self.resource.collection_get()

--- a/cliquet/tests/resource/test_object_permissions.py
+++ b/cliquet/tests/resource/test_object_permissions.py
@@ -71,8 +71,8 @@ class SpecifyRecordPermissionTest(PermissionTest):
         record_id = record['id']
         record_uri = '/articles/%s' % record_id
         self.permission.add_principal_to_ace(record_uri, 'read', 'fxa:user')
+        self.resource.context.prefixed_userid = 'basic:userid'
         self.resource.record_id = record_id
-        self.resource.request.authenticated_userid = 'basic:userid'
         self.resource.request.validated = {'data': {}}
         self.resource.request.path = record_uri
 

--- a/cliquet/tests/resource/test_preconditions.py
+++ b/cliquet/tests/resource/test_preconditions.py
@@ -10,7 +10,8 @@ class NotModifiedTest(BaseTest):
         super(NotModifiedTest, self).setUp()
         self.stored = self.collection.create_record({})
 
-        self.resource = BaseResource(self.get_request())
+        self.resource = BaseResource(request=self.get_request(),
+                                     context=self.get_context())
         self.resource.collection_get()
         current = self.last_response.headers['ETag']
         self.resource.request.headers['If-None-Match'] = current
@@ -63,6 +64,7 @@ class ModifiedMeanwhileTest(BaseTest):
     def setUp(self):
         super(ModifiedMeanwhileTest, self).setUp()
         self.stored = self.collection.create_record({})
+
         self.resource.collection_get()
         current = self.last_response.headers['ETag'][1:-1].decode('utf-8')
         previous = int(current) - 10

--- a/cliquet/tests/resource/test_record.py
+++ b/cliquet/tests/resource/test_record.py
@@ -96,7 +96,8 @@ class PatchTest(BaseTest):
     def test_collection_timestamp_is_not_updated_if_no_field_changed(self):
         self.resource.request.json = {'data': {'some': 'change'}}
         self.resource.patch()
-        self.resource = BaseResource(self.get_request())
+        self.resource = BaseResource(request=self.get_request(),
+                                     context=self.get_context())
         self.resource.collection_get()['data']
         last_modified = int(self.last_response.headers['ETag'][1:-1])
         self.assertEquals(self.result['last_modified'], last_modified)

--- a/cliquet/tests/resource/test_sync.py
+++ b/cliquet/tests/resource/test_sync.py
@@ -35,7 +35,8 @@ class SinceModifiedTest(ThreadMixin, BaseTest):
     def test_the_timestamp_header_is_equal_to_last_modification(self):
         result = self.resource.collection_post()['data']
         modification = result['last_modified']
-        self.resource = BaseResource(self.get_request())
+        self.resource = BaseResource(request=self.get_request(),
+                                     context=self.get_context())
         self.resource.collection_get()
         header = int(self.last_response.headers['ETag'][1:-1])
         self.assertEqual(header, modification)

--- a/cliquet/tests/resource/test_views.py
+++ b/cliquet/tests/resource/test_views.py
@@ -172,9 +172,8 @@ class RecordAuthzGrantedTest(AuthzAuthnTest):
 class RecordAuthzDeniedTest(AuthzAuthnTest):
     def setUp(self):
         super(RecordAuthzDeniedTest, self).setUp()
-        self.app.app.registry.permission.add_principal_to_ace(
-            self.collection_url, 'mushroom:create', self.principal)
-
+        # Add permission to create a sample record.
+        self.add_permission(self.collection_url, 'mushroom:create')
         resp = self.app.post_json(self.collection_url,
                                   {'data': MINIMALIST_RECORD},
                                   headers=self.headers)

--- a/cliquet/tests/support.py
+++ b/cliquet/tests/support.py
@@ -20,7 +20,7 @@ from cliquet.storage import generators
 from cliquet.tests.testapp import main as testapp
 
 # This is the principal a connected user should have (in the tests).
-USER_PRINCIPAL = ('basicauth_9f2d363f98418b13253d6d7193fc88690302'
+USER_PRINCIPAL = ('basicauth:9f2d363f98418b13253d6d7193fc88690302'
                   'ab0ae21295521f6029dffe9dc3b0')
 
 
@@ -34,6 +34,8 @@ class DummyRequest(mock.MagicMock):
         self.headers = {}
         self.errors = cornice_errors.Errors(request=self)
         self.authenticated_userid = 'bob'
+        self.authn_type = 'basicauth'
+        self.prefixed_userid = 'basicauth:bob'
         self.json = {}
         self.validated = {}
         self.matchdict = {}

--- a/cliquet/tests/support.py
+++ b/cliquet/tests/support.py
@@ -118,9 +118,8 @@ class ThreadMixin(object):
 @implementer(IAuthorizationPolicy)
 class AllowAuthorizationPolicy(object):
     def permits(self, context, principals, permission):
-        if USER_PRINCIPAL in principals:
-            return True
-        return False
+        # Cliquet default authz policy uses prefixed_userid.
+        return USER_PRINCIPAL in (principals + [context.prefixed_userid])
 
     def principals_allowed_by_permission(self, context, permission):
         raise NotImplementedError()  # PRAGMA NOCOVER

--- a/cliquet/tests/test_authentication.py
+++ b/cliquet/tests/test_authentication.py
@@ -52,10 +52,6 @@ class BasicAuthenticationPolicyTest(unittest.TestCase):
         self.request = DummyRequest()
         self.request.headers['Authorization'] = 'Basic bWF0Og=='
 
-    def test_prefixes_users_with_basicauth(self):
-        user_id = self.policy.unauthenticated_userid(self.request)
-        self.assertTrue(user_id.startswith('basicauth_'))
-
     @mock.patch('cliquet.utils.hmac_digest')
     def test_userid_is_hashed(self, mocked):
         mocked.return_value = 'yeah'

--- a/cliquet/tests/test_initialization.py
+++ b/cliquet/tests/test_initialization.py
@@ -199,7 +199,7 @@ class StatsDConfigurationTest(unittest.TestCase):
         app = webtest.TestApp(self.config.make_wsgi_app())
         headers = {'Authorization': 'Basic bWF0Og=='}
         app.get('/v0/__heartbeat__', headers=headers)
-        mocked().count.assert_any_call('users', unique='basicauth_mat')
+        mocked().count.assert_any_call('users', unique='mat')
 
     @mock.patch('cliquet.statsd.Client')
     def test_statsd_counts_authentication_types(self, mocked):


### PR DESCRIPTION
The main idea of this is to be able to use any kind of authn policy available for Pyramid.

Prefixing user_id with authentication type should thus be done by Cliquet.

See also https://github.com/mozilla-services/cliquet-fxa/pull/5