### PR TITLE
Using a wrong HTTP verb raise a 500

### DIFF
--- a/cliquet/authorization.py
+++ b/cliquet/authorization.py
@@ -103,7 +103,11 @@ class RouteFactory(object):
                 else:
                     permission = "write"
             else:
-                permission = self.method_permissions[request.method.lower()]
+                method = request.method.lower()
+                try:
+                    permission = self.method_permissions[method]
+                except KeyError:
+                    permission = None
 
             resource_name = service.viewset.get_name(service.resource)
             check_permission = functools.partial(

--- a/cliquet/authorization.py
+++ b/cliquet/authorization.py
@@ -104,10 +104,7 @@ class RouteFactory(object):
                     permission = "write"
             else:
                 method = request.method.lower()
-                try:
-                    permission = self.method_permissions[method]
-                except KeyError:
-                    permission = None
+                permission = self.method_permissions.get(method)
 
             resource_name = service.viewset.get_name(service.resource)
             check_permission = functools.partial(

--- a/cliquet/tests/test_authorization.py
+++ b/cliquet/tests/test_authorization.py
@@ -35,6 +35,9 @@ class RouteFactoryTest(unittest.TestCase):
 
             self.assertEquals(context.required_permission, permission)
 
+    def test_http_unknown_does_not_raise_a_500(self):
+        self.assert_request_resolves_to("unknown", None)
+
     def test_http_get_resolves_in_a_read_permission(self):
         self.assert_request_resolves_to("get", "read")
 


### PR DESCRIPTION
I sent:

```echo '{"data": {}}' | http PUTT https://kinto.dev.mozaws.net/v1/buckets/default --auth 'user:password'```

```  File "/home/ubuntu/venvs/kinto/local/lib/python2.7/site-packages/cliquet/authorization.py", line 85, in __init__
    permission = self.method_permissions[request.method.lower()]
KeyError: 'putt'```
