### PR TITLE
Sometimes the collection_timestamp < record.last_modified

### DIFF
--- a/cliquet/authorization.py
+++ b/cliquet/authorization.py
@@ -61,13 +61,8 @@ class RouteFactory(object):
     }
 
     def __init__(self, request):
-        # Prefix the user id with the authn policy type name.
-        user_id = request.authenticated_userid
-        # This comes from ``cliquet.initialization.setup_authentication()``.
-        authn_type = getattr(request, 'authn_type', None)
-        self.prefixed_userid = None
-        if user_id and authn_type:
-            self.prefixed_userid = '%s:%s' % (authn_type.lower(), user_id)
+        # We need it in permits as well
+        self.prefixed_userid = getattr(request, "prefixed_userid", None)
 
         # Store service, resource, record and required permission.
         service = utils.current_service(request)

--- a/cliquet/authorization.py
+++ b/cliquet/authorization.py
@@ -61,7 +61,7 @@ class RouteFactory(object):
     }
 
     def __init__(self, request):
-        # We need it in permits as well
+        # Make it available for the authorization policy.
         self.prefixed_userid = getattr(request, "prefixed_userid", None)
 
         # Store service, resource, record and required permission.

--- a/cliquet/initialization.py
+++ b/cliquet/initialization.py
@@ -88,6 +88,21 @@ def setup_authentication(config):
 
     config.add_subscriber(on_policy_selected, MultiAuthPolicySelected)
 
+    # Build the prefixed_userid
+    def on_new_request(event):
+        # This comes from ``cliquet.initialization.setup_authentication()``.
+        authn_type = getattr(event.request, 'authn_type', None)
+
+        # Prefix the user id with the authn policy type name.
+        user_id = event.request.authenticated_userid
+
+        event.request.prefixed_userid = None
+        if user_id and authn_type:
+            event.request.prefixed_userid = '%s:%s' % (authn_type.lower(),
+                                                       user_id)
+
+    config.add_subscriber(on_new_request, NewRequest)
+
 
 def setup_backoff(config):
     """Attach HTTP requests/responses objects.

--- a/cliquet/initialization.py
+++ b/cliquet/initialization.py
@@ -90,7 +90,6 @@ def setup_authentication(config):
 
     # Build the prefixed_userid
     def on_new_request(event):
-        # This comes from ``cliquet.initialization.setup_authentication()``.
         authn_type = getattr(event.request, 'authn_type', None)
 
         # Prefix the user id with the authn policy type name.

--- a/cliquet/resource.py
+++ b/cliquet/resource.py
@@ -257,7 +257,7 @@ class BaseResource(object):
 
     def __init__(self, request, context=None):
         # Collections are isolated by user.
-        parent_id = request.prefixed_userid
+        parent_id = self.get_parent_id(request)
 
         # Authentication to storage is transmitted as is (cf. cloud_storage).
         auth = request.headers.get('Authorization')
@@ -277,6 +277,9 @@ class BaseResource(object):
         # Log resource context.
         logger.bind(collection_id=self.collection.collection_id,
                     collection_timestamp=self.timestamp)
+
+    def get_parent_id(self, request):
+        return getattr(request, 'prefixed_userid', None)
 
     def is_known_field(self, field):
         """Return ``True`` if `field` is defined in the resource mapping.

--- a/cliquet/resource.py
+++ b/cliquet/resource.py
@@ -279,6 +279,15 @@ class BaseResource(object):
                     collection_timestamp=self.timestamp)
 
     def get_parent_id(self, request):
+        """Return the parent_id of the resource with regards to the current
+        request.
+
+        :param request:
+            The request used to create the resource.
+
+        :rtype: str
+
+        """
         return getattr(request, 'prefixed_userid', None)
 
     def is_known_field(self, field):

--- a/cliquet/resource.py
+++ b/cliquet/resource.py
@@ -255,9 +255,9 @@ class BaseResource(object):
     mapping = ResourceSchema()
     """Schema to validate records."""
 
-    def __init__(self, request, context):
+    def __init__(self, request, context=None):
         # Collections are isolated by user.
-        parent_id = context.prefixed_userid
+        parent_id = request.prefixed_userid
 
         # Authentication to storage is transmitted as is (cf. cloud_storage).
         auth = request.headers.get('Authorization')
@@ -1014,7 +1014,7 @@ class ProtectedResource(BaseResource):
 
         if add_write_perm:
             write_principals = permissions.setdefault('write', [])
-            user_principal = self.context.prefixed_userid
+            user_principal = self.request.prefixed_userid
             if user_principal not in write_principals:
                 write_principals.insert(0, user_principal)
 

--- a/cliquet/tests/resource/test_collection.py
+++ b/cliquet/tests/resource/test_collection.py
@@ -73,12 +73,12 @@ class IsolatedCollectionsTest(BaseTest):
 
     def get_request(self):
         request = super(IsolatedCollectionsTest, self).get_request()
-        request.prefixed_userid = 'basic:alice'
+        request.prefixed_userid = 'basicauth:alice'
         return request
 
     def get_context(self):
         context = super(IsolatedCollectionsTest, self).get_context()
-        context.prefixed_userid = 'basic:alice'
+        context.prefixed_userid = 'basicauth:alice'
         return context
 
     def test_list_is_filtered_by_user(self):
@@ -90,7 +90,7 @@ class IsolatedCollectionsTest(BaseTest):
         self.resource.request.validated = {'data': {'some': 'record'}}
         self.resource.put()
         self.collection.get_record(record_id=self.stored['id'],
-                                   parent_id='basic:alice')  # not raising
+                                   parent_id='basicauth:alice')  # not raising
 
     def test_cannot_modify_record_of_other_user(self):
         self.assertRaises(httpexceptions.HTTPNotFound, self.resource.patch)

--- a/cliquet/tests/resource/test_collection.py
+++ b/cliquet/tests/resource/test_collection.py
@@ -71,9 +71,14 @@ class IsolatedCollectionsTest(BaseTest):
         self.stored = self.collection.create_record({}, parent_id='bob')
         self.resource.record_id = self.stored['id']
 
+    def get_request(self):
+        request = super(IsolatedCollectionsTest, self).get_request()
+        request.prefixed_userid = 'basic:alice'
+        return request
+
     def get_context(self):
         context = super(IsolatedCollectionsTest, self).get_context()
-        context.prefixed_userid = 'alice'
+        context.prefixed_userid = 'basic:alice'
         return context
 
     def test_list_is_filtered_by_user(self):
@@ -85,7 +90,7 @@ class IsolatedCollectionsTest(BaseTest):
         self.resource.request.validated = {'data': {'some': 'record'}}
         self.resource.put()
         self.collection.get_record(record_id=self.stored['id'],
-                                   parent_id='alice')  # not raising
+                                   parent_id='basic:alice')  # not raising
 
     def test_cannot_modify_record_of_other_user(self):
         self.assertRaises(httpexceptions.HTTPNotFound, self.resource.patch)

--- a/cliquet/tests/resource/test_object_permissions.py
+++ b/cliquet/tests/resource/test_object_permissions.py
@@ -71,7 +71,7 @@ class SpecifyRecordPermissionTest(PermissionTest):
         record_id = record['id']
         record_uri = '/articles/%s' % record_id
         self.permission.add_principal_to_ace(record_uri, 'read', 'fxa:user')
-        self.resource.context.prefixed_userid = 'basic:userid'
+        self.resource.request.prefixed_userid = 'basic:userid'
         self.resource.record_id = record_id
         self.resource.request.validated = {'data': {}}
         self.resource.request.path = record_uri

--- a/cliquet/tests/resource/test_object_permissions.py
+++ b/cliquet/tests/resource/test_object_permissions.py
@@ -16,6 +16,16 @@ class PermissionTest(BaseTest):
         return request
 
 
+class ProtectedResourceTest(BaseTest):
+    resource_class = ProtectedResource
+
+    def test_resource_can_be_created_without_context(self):
+        try:
+            ProtectedResource(self.get_request())
+        except Exception as e:
+            self.fail(e)
+
+
 class CollectionPermissionTest(PermissionTest):
     def setUp(self):
         super(CollectionPermissionTest, self).setUp()

--- a/cliquet/tests/resource/test_object_permissions.py
+++ b/cliquet/tests/resource/test_object_permissions.py
@@ -80,7 +80,8 @@ class SpecifyRecordPermissionTest(PermissionTest):
         self.resource.request.path = '/articles'
         self.resource.request.method = 'POST'
         result = self.resource.collection_post()
-        self.assertEqual(result['permissions'], {'write': ['basicauth:userid']})
+        self.assertEqual(result['permissions'],
+                         {'write': ['basicauth:userid']})
 
     def test_write_permission_is_given_to_put(self):
         self.resource.request.method = 'PUT'

--- a/cliquet/tests/resource/test_object_permissions.py
+++ b/cliquet/tests/resource/test_object_permissions.py
@@ -16,16 +16,6 @@ class PermissionTest(BaseTest):
         return request
 
 
-class ProtectedResourceTest(BaseTest):
-    resource_class = ProtectedResource
-
-    def test_resource_can_be_created_without_context(self):
-        try:
-            ProtectedResource(self.get_request())
-        except Exception as e:
-            self.fail(e)
-
-
 class CollectionPermissionTest(PermissionTest):
     def setUp(self):
         super(CollectionPermissionTest, self).setUp()
@@ -81,7 +71,7 @@ class SpecifyRecordPermissionTest(PermissionTest):
         record_id = record['id']
         record_uri = '/articles/%s' % record_id
         self.permission.add_principal_to_ace(record_uri, 'read', 'fxa:user')
-        self.resource.request.prefixed_userid = 'basic:userid'
+        self.resource.request.prefixed_userid = 'basicauth:userid'
         self.resource.record_id = record_id
         self.resource.request.validated = {'data': {}}
         self.resource.request.path = record_uri
@@ -90,13 +80,13 @@ class SpecifyRecordPermissionTest(PermissionTest):
         self.resource.request.path = '/articles'
         self.resource.request.method = 'POST'
         result = self.resource.collection_post()
-        self.assertEqual(result['permissions'], {'write': ['basic:userid']})
+        self.assertEqual(result['permissions'], {'write': ['basicauth:userid']})
 
     def test_write_permission_is_given_to_put(self):
         self.resource.request.method = 'PUT'
         result = self.resource.put()
         self.assertEqual(result['permissions'],
-                         {'read': ['fxa:user'], 'write': ['basic:userid']})
+                         {'read': ['fxa:user'], 'write': ['basicauth:userid']})
 
     def test_permissions_can_be_specified_in_collection_post(self):
         perms = {'write': ['jean-louis']}
@@ -105,7 +95,7 @@ class SpecifyRecordPermissionTest(PermissionTest):
         self.resource.request.validated = {'data': {}, 'permissions': perms}
         result = self.resource.collection_post()
         self.assertEqual(result['permissions'],
-                         {'write': ['basic:userid', 'jean-louis']})
+                         {'write': ['basicauth:userid', 'jean-louis']})
 
     def test_permissions_are_replaced_with_put(self):
         perms = {'write': ['jean-louis']}

--- a/cliquet/tests/support.py
+++ b/cliquet/tests/support.py
@@ -34,8 +34,8 @@ class DummyRequest(mock.MagicMock):
         self.headers = {}
         self.errors = cornice_errors.Errors(request=self)
         self.authenticated_userid = 'bob'
-        self.authn_type = 'basic'
-        self.prefixed_userid = 'basic:bob'
+        self.authn_type = 'basicauth'
+        self.prefixed_userid = 'basicauth:bob'
         self.json = {}
         self.validated = {}
         self.matchdict = {}

--- a/cliquet/tests/support.py
+++ b/cliquet/tests/support.py
@@ -34,8 +34,8 @@ class DummyRequest(mock.MagicMock):
         self.headers = {}
         self.errors = cornice_errors.Errors(request=self)
         self.authenticated_userid = 'bob'
-        self.authn_type = 'basicauth'
-        self.prefixed_userid = 'basicauth:bob'
+        self.authn_type = 'basic'
+        self.prefixed_userid = 'basic:bob'
         self.json = {}
         self.validated = {}
         self.matchdict = {}


### PR DESCRIPTION
```http
HTTP/1.1 200 OK
Access-Control-Expose-Headers: Backoff, Retry-After, Alert, Next-Page, Total-Records, Last-Modified, ETag
Backoff: 10
Connection: keep-alive
Content-Length: 104
Content-Type: application/json; charset=UTF-8
Date: Fri, 19 Jun 2015 08:31:46 GMT
ETag: "1434702683855"
Last-Modified: Fri, 19 Jun 2015 08:31:23 GMT
Server: nginx/1.4.6 (Ubuntu)
Total-Records: 1

{
    "data": [
        {
            "id": "64a8f2a2-2f32-4b72-9bc1-0b1a244f998a", 
            "last_modified": 1434702683856, 
            "title": "amanite"
        }
    ]
}
```

As you can see:

``ETag: "1434702683855"`` and ``"last_modified": 1434702683856, ``

So basically ``1434702683855 < 1434702683856`` which should not be possible ever.

Here I was using the redis backend.