### PR TITLE
Make sure psycopg is optional.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
     - TOX_ENV=py27
     - TOX_ENV=py34
     - TOX_ENV=pypy
+    - TOX_ENV=py27-raw
     - TOX_ENV=flake8
     - TOX_ENV=docs
 install:

--- a/cliquet/initialization.py
+++ b/cliquet/initialization.py
@@ -9,7 +9,7 @@ import webob
 try:
     import newrelic.agent
 except ImportError:  # pragma: no cover
-    pass
+    newrelic = None
 
 try:
     from werkzeug.contrib.profiler import ProfilerMiddleware

--- a/cliquet/statsd.py
+++ b/cliquet/statsd.py
@@ -3,7 +3,8 @@ from __future__ import absolute_import
 try:
     import statsd as statsd_module
 except ImportError:  # pragma: no cover
-    pass
+    statsd_module = None
+
 from six.moves.urllib import parse as urlparse
 
 from cliquet import utils

--- a/cliquet/storage/postgresql/__init__.py
+++ b/cliquet/storage/postgresql/__init__.py
@@ -3,8 +3,6 @@ import os
 import warnings
 from collections import defaultdict
 
-from cliquet.utils import psycopg2
-
 import six
 from six.moves.urllib import parse as urlparse
 
@@ -12,7 +10,7 @@ from cliquet import logger
 from cliquet.storage import (
     StorageBase, exceptions, Filter,
     DEFAULT_ID_FIELD, DEFAULT_MODIFIED_FIELD, DEFAULT_DELETED_FIELD)
-from cliquet.utils import COMPARISON, json
+from cliquet.utils import COMPARISON, json, psycopg2
 
 if psycopg2 is not None:
     import psycopg2.extras

--- a/cliquet/storage/postgresql/__init__.py
+++ b/cliquet/storage/postgresql/__init__.py
@@ -12,7 +12,7 @@ from cliquet.storage import (
     DEFAULT_ID_FIELD, DEFAULT_MODIFIED_FIELD, DEFAULT_DELETED_FIELD)
 from cliquet.utils import COMPARISON, json, psycopg2
 
-if psycopg2 is not None:
+if psycopg2:
     import psycopg2.extras
     import psycopg2.pool
 
@@ -26,9 +26,8 @@ class PostgreSQLClient(object):
 
     def __init__(self, *args, **kwargs):
         if psycopg2 is None:
-            raise ImportWarning(
-                "You must install psycopg2 to use the postgresql backend"
-            )
+            message = "You must install psycopg2 to use the postgresql backend"
+            raise ImportWarning(message)
 
         pool_size = kwargs.pop('pool_size')
         self._conn_kwargs = kwargs

--- a/cliquet/storage/postgresql/__init__.py
+++ b/cliquet/storage/postgresql/__init__.py
@@ -4,8 +4,14 @@ import warnings
 from collections import defaultdict
 
 from cliquet.utils import psycopg2
-import psycopg2.extras
-import psycopg2.pool
+
+if psycopg2 is None:
+    warnings.warn("You must install psycopg2 to use the postgresql backend",
+                  ImportWarning)
+else:
+    import psycopg2.extras
+    import psycopg2.pool
+
 import six
 from six.moves.urllib import parse as urlparse
 
@@ -15,9 +21,9 @@ from cliquet.storage import (
     DEFAULT_ID_FIELD, DEFAULT_MODIFIED_FIELD, DEFAULT_DELETED_FIELD)
 from cliquet.utils import COMPARISON, json
 
-
-psycopg2.extensions.register_type(psycopg2.extensions.UNICODE)
-psycopg2.extensions.register_type(psycopg2.extensions.UNICODEARRAY)
+if psycopg2 is not None:
+    psycopg2.extensions.register_type(psycopg2.extensions.UNICODE)
+    psycopg2.extensions.register_type(psycopg2.extensions.UNICODEARRAY)
 
 
 class PostgreSQLClient(object):
@@ -25,6 +31,11 @@ class PostgreSQLClient(object):
     pool = None
 
     def __init__(self, *args, **kwargs):
+        if psycopg2 is None:
+            raise ImportWarning(
+                "You must install psycopg2 to use the postgresql backend"
+            )
+
         pool_size = kwargs.pop('pool_size')
         self._conn_kwargs = kwargs
         pool_klass = psycopg2.pool.ThreadedConnectionPool

--- a/cliquet/storage/postgresql/__init__.py
+++ b/cliquet/storage/postgresql/__init__.py
@@ -5,13 +5,6 @@ from collections import defaultdict
 
 from cliquet.utils import psycopg2
 
-if psycopg2 is None:
-    warnings.warn("You must install psycopg2 to use the postgresql backend",
-                  ImportWarning)
-else:
-    import psycopg2.extras
-    import psycopg2.pool
-
 import six
 from six.moves.urllib import parse as urlparse
 
@@ -22,6 +15,9 @@ from cliquet.storage import (
 from cliquet.utils import COMPARISON, json
 
 if psycopg2 is not None:
+    import psycopg2.extras
+    import psycopg2.pool
+
     psycopg2.extensions.register_type(psycopg2.extensions.UNICODE)
     psycopg2.extensions.register_type(psycopg2.extensions.UNICODEARRAY)
 

--- a/cliquet/tests/support.py
+++ b/cliquet/tests/support.py
@@ -18,6 +18,7 @@ from zope.interface import implementer
 from cliquet import DEFAULT_SETTINGS
 from cliquet.storage import generators
 from cliquet.tests.testapp import main as testapp
+from cliquet.utils import psycopg2
 
 # This is the principal a connected user should have (in the tests).
 USER_PRINCIPAL = ('basicauth:9f2d363f98418b13253d6d7193fc88690302'
@@ -145,3 +146,5 @@ def authorize(permits=True, authz_class=None):
     return wrapper
 
 skip_if_travis = unittest.skipIf('TRAVIS' in os.environ, "travis")
+skip_if_no_postgresql = unittest.skipIf(psycopg2 is None,
+                                        "postgresql is not installed.")

--- a/cliquet/tests/test_cache.py
+++ b/cliquet/tests/test_cache.py
@@ -8,7 +8,7 @@ from cliquet.storage import exceptions
 from cliquet.cache import (CacheBase, postgresql as postgresql_backend,
                            redis as redis_backend, memory as memory_backend)
 
-from .support import unittest
+from .support import unittest, skip_if_no_postgresql
 
 
 class CacheBaseTest(unittest.TestCase):
@@ -154,7 +154,7 @@ class RedisCacheTest(BaseTestCache, unittest.TestCase):
             side_effect=redis.RedisError)
 
 
-@unittest.skipIf(psycopg2 is None, "postgresql is not installed.")
+@skip_if_no_postgresql
 class PostgreSQLCacheTest(BaseTestCache, unittest.TestCase):
     backend = postgresql_backend
     settings = {

--- a/cliquet/tests/test_cache.py
+++ b/cliquet/tests/test_cache.py
@@ -33,8 +33,8 @@ class BaseTestCache(object):
     backend = None
     settings = {}
 
-    def __init__(self, *args, **kwargs):
-        super(BaseTestCache, self).__init__(*args, **kwargs)
+    def setUp(self):
+        super(BaseTestCache, self).setUp()
         self.cache = self.backend.load_from_config(self._get_config())
         self.cache.initialize_schema()
         self.request = None
@@ -146,14 +146,15 @@ class RedisCacheTest(BaseTestCache, unittest.TestCase):
         'cliquet.cache_pool_size': 10
     }
 
-    def __init__(self, *args, **kwargs):
-        super(RedisCacheTest, self).__init__(*args, **kwargs)
+    def setUp(self):
+        super(RedisCacheTest, self).setUp()
         self.client_error_patcher = mock.patch.object(
             self.cache._client,
             'execute_command',
             side_effect=redis.RedisError)
 
 
+@unittest.skipIf(psycopg2 is None, "postgresql is not installed.")
 class PostgreSQLCacheTest(BaseTestCache, unittest.TestCase):
     backend = postgresql_backend
     settings = {
@@ -162,8 +163,8 @@ class PostgreSQLCacheTest(BaseTestCache, unittest.TestCase):
             'postgres://postgres:postgres@localhost:5432/testdb'
     }
 
-    def __init__(self, *args, **kwargs):
-        super(PostgreSQLCacheTest, self).__init__(*args, **kwargs)
+    def setUp(self):
+        super(PostgreSQLCacheTest, self).setUp()
         self.client_error_patcher = mock.patch.object(
             self.cache.pool,
             'getconn',

--- a/cliquet/tests/test_initialization.py
+++ b/cliquet/tests/test_initialization.py
@@ -100,6 +100,8 @@ class InitializationTest(unittest.TestCase):
 
 class ApplicationWrapperTest(unittest.TestCase):
 
+    @unittest.skipIf(initialization.newrelic is None,
+                     "newrelic is not installed.")
     @mock.patch('cliquet.initialization.newrelic.agent')
     def test_newrelic_is_included_if_defined(self, mocked_newrelic):
         settings = {
@@ -111,6 +113,8 @@ class ApplicationWrapperTest(unittest.TestCase):
         mocked_newrelic.initialize.assert_called_with('/foo/bar.ini', 'test')
         self.assertEquals(app, 'wrappedApp')
 
+    @unittest.skipIf(initialization.newrelic is None,
+                     "newrelic is not installed.")
     @mock.patch('cliquet.initialization.newrelic.agent')
     def test_newrelic_is_not_included_if_set_to_false(self, mocked_newrelic):
         settings = {'cliquet.newrelic_config': False}

--- a/cliquet/tests/test_permission.py
+++ b/cliquet/tests/test_permission.py
@@ -8,7 +8,7 @@ from cliquet.permission import (PermissionBase, redis as redis_backend,
                                 memory as memory_backend,
                                 postgresql as postgresql_backend)
 
-from .support import unittest
+from .support import unittest, skip_if_no_postgresql
 
 
 class PermissionBaseTest(unittest.TestCase):
@@ -245,7 +245,7 @@ class RedisPermissionTest(BaseTestPermission, unittest.TestCase):
                 side_effect=redis.RedisError)]
 
 
-@unittest.skipIf(psycopg2 is None, "postgresql is not installed.")
+@skip_if_no_postgresql
 class PostgreSQLPermissionTest(BaseTestPermission, unittest.TestCase):
     backend = postgresql_backend
     settings = {

--- a/cliquet/tests/test_permission.py
+++ b/cliquet/tests/test_permission.py
@@ -35,8 +35,8 @@ class BaseTestPermission(object):
     backend = None
     settings = {}
 
-    def __init__(self, *args, **kwargs):
-        super(BaseTestPermission, self).__init__(*args, **kwargs)
+    def setUp(self):
+        super(BaseTestPermission, self).setUp()
         self.permission = self.backend.load_from_config(self._get_config())
         self.permission.initialize_schema()
         self.request = None
@@ -232,8 +232,8 @@ class RedisPermissionTest(BaseTestPermission, unittest.TestCase):
         'cliquet.permission_pool_size': 10
     }
 
-    def __init__(self, *args, **kwargs):
-        super(RedisPermissionTest, self).__init__(*args, **kwargs)
+    def setUp(self):
+        super(RedisPermissionTest, self).setUp()
         self.client_error_patcher = [
             mock.patch.object(
                 self.permission._client,
@@ -245,6 +245,7 @@ class RedisPermissionTest(BaseTestPermission, unittest.TestCase):
                 side_effect=redis.RedisError)]
 
 
+@unittest.skipIf(psycopg2 is None, "postgresql is not installed.")
 class PostgreSQLPermissionTest(BaseTestPermission, unittest.TestCase):
     backend = postgresql_backend
     settings = {
@@ -253,8 +254,8 @@ class PostgreSQLPermissionTest(BaseTestPermission, unittest.TestCase):
             'postgres://postgres:postgres@localhost:5432/testdb'
     }
 
-    def __init__(self, *args, **kwargs):
-        super(PostgreSQLPermissionTest, self).__init__(*args, **kwargs)
+    def setUp(self):
+        super(PostgreSQLPermissionTest, self).setUp()
         self.client_error_patcher = [mock.patch.object(
             self.permission.pool,
             'getconn',

--- a/cliquet/tests/test_statsd.py
+++ b/cliquet/tests/test_statsd.py
@@ -16,6 +16,7 @@ class TestedClass(object):
         pass
 
 
+@unittest.skipIf(not statsd.statsd_module, "statsd is not installed.")
 class StatsdClientTest(unittest.TestCase):
     settings = {
         'cliquet.statsd_url': 'udp://foo:1234',

--- a/cliquet/tests/test_storage.py
+++ b/cliquet/tests/test_storage.py
@@ -70,23 +70,14 @@ class BaseTestStorage(object):
 
     settings = {}
 
-    def __init__(self, *args, **kwargs):
-        super(BaseTestStorage, self).__init__(*args, **kwargs)
+    def setUp(self):
+        super(BaseTestStorage, self).setUp()
         self.storage = self.backend.load_from_config(self._get_config())
         self.storage.initialize_schema()
         self.id_field = 'id'
         self.modified_field = 'last_modified'
         self.client_error_patcher = None
 
-    def _get_config(self, settings=None):
-        """Mock Pyramid config object.
-        """
-        if settings is None:
-            settings = self.settings
-        return mock.Mock(get_settings=mock.Mock(return_value=settings))
-
-    def setUp(self):
-        super(BaseTestStorage, self).setUp()
         self.record = {'foo': 'bar'}
         self.storage_kw = {
             'collection_id': 'test',
@@ -95,6 +86,13 @@ class BaseTestStorage(object):
         }
         self.other_parent_id = '5678'
         self.other_auth = 'Basic bWF0OjE='
+
+    def _get_config(self, settings=None):
+        """Mock Pyramid config object.
+        """
+        if settings is None:
+            settings = self.settings
+        return mock.Mock(get_settings=mock.Mock(return_value=settings))
 
     def tearDown(self):
         mock.patch.stopall()
@@ -778,8 +776,8 @@ class StorageTest(ThreadMixin,
 class MemoryStorageTest(StorageTest, unittest.TestCase):
     backend = memory
 
-    def __init__(self, *args, **kwargs):
-        super(MemoryStorageTest, self).__init__(*args, **kwargs)
+    def setUp(self):
+        super(MemoryStorageTest, self).setUp()
         self.client_error_patcher = mock.patch.object(
             self.storage,
             '_bump_timestamp',
@@ -805,8 +803,8 @@ class RedisStorageTest(MemoryStorageTest, unittest.TestCase):
         'cliquet.storage_url': ''
     }
 
-    def __init__(self, *args, **kwargs):
-        super(RedisStorageTest, self).__init__(*args, **kwargs)
+    def setUp(self):
+        super(RedisStorageTest, self).setUp()
         self.client_error_patcher = mock.patch.object(
             self.storage._client.connection_pool,
             'get_connection',
@@ -834,6 +832,7 @@ class RedisStorageTest(MemoryStorageTest, unittest.TestCase):
                 self.storage.get_all(**self.storage_kw)  # not raising
 
 
+@unittest.skipIf(psycopg2 is None, "postgresql is not installed.")
 class PostgresqlStorageTest(StorageTest, unittest.TestCase):
     backend = postgresql
     settings = {
@@ -843,8 +842,8 @@ class PostgresqlStorageTest(StorageTest, unittest.TestCase):
             'postgres://postgres:postgres@localhost:5432/testdb'
     }
 
-    def __init__(self, *args, **kwargs):
-        super(PostgresqlStorageTest, self).__init__(*args, **kwargs)
+    def setUp(self):
+        super(PostgresqlStorageTest, self).setUp()
         self.client_error_patcher = mock.patch.object(
             self.storage.pool,
             'getconn',

--- a/cliquet/tests/test_storage.py
+++ b/cliquet/tests/test_storage.py
@@ -11,7 +11,8 @@ from cliquet.storage import (
     Sort, StorageBase
 )
 
-from .support import unittest, ThreadMixin, DummyRequest, skip_if_travis
+from .support import (unittest, ThreadMixin, DummyRequest,
+                      skip_if_travis, skip_if_no_postgresql)
 
 
 RECORD_ID = '472be9ec-26fe-461b-8282-9c4e4b207ab3'
@@ -832,7 +833,7 @@ class RedisStorageTest(MemoryStorageTest, unittest.TestCase):
                 self.storage.get_all(**self.storage_kw)  # not raising
 
 
-@unittest.skipIf(psycopg2 is None, "postgresql is not installed.")
+@skip_if_no_postgresql
 class PostgresqlStorageTest(StorageTest, unittest.TestCase):
     backend = postgresql
     settings = {

--- a/cliquet/tests/test_storage_migrations.py
+++ b/cliquet/tests/test_storage_migrations.py
@@ -143,8 +143,14 @@ class PostgresqlStorageMigrationTest(unittest.TestCase):
         self.assertEqual(version, self.version)
 
 
-@unittest.skipIf(postgresql.psycopg2 is not None, "postgresql is installed.")
 class PostgresqlExceptionRaisedTest(unittest.TestCase):
+    def setUp(self):
+        self.psycopg2 = postgresql.psycopg2
+
+    def tearDown(self):
+        postgresql.psycopg2 = self.psycopg2
+
     def test_postgresql_usage_raise_an_error_if_postgresql_not_installed(self):
+        postgresql.psycopg2 = None
         with self.assertRaises(ImportWarning):
             postgresql.PostgreSQLClient()

--- a/cliquet/tests/test_storage_migrations.py
+++ b/cliquet/tests/test_storage_migrations.py
@@ -5,10 +5,10 @@ import mock
 from cliquet.storage import postgresql
 from cliquet.utils import json
 
-from .support import unittest
+from .support import unittest, skip_if_no_postgresql
 
 
-@unittest.skipIf(postgresql.psycopg2 is None, "postgresql is not installed.")
+@skip_if_no_postgresql
 class PostgresqlStorageMigrationTest(unittest.TestCase):
     def setUp(self):
         from .test_storage import PostgresqlStorageTest

--- a/cliquet/tests/test_storage_migrations.py
+++ b/cliquet/tests/test_storage_migrations.py
@@ -8,6 +8,7 @@ from cliquet.utils import json
 from .support import unittest
 
 
+@unittest.skipIf(postgresql.psycopg2 is None, "postgresql is not installed.")
 class PostgresqlStorageMigrationTest(unittest.TestCase):
     def setUp(self):
         from .test_storage import PostgresqlStorageTest
@@ -140,3 +141,10 @@ class PostgresqlStorageMigrationTest(unittest.TestCase):
         # Version matches current one.
         version = self.storage._get_installed_version()
         self.assertEqual(version, self.version)
+
+
+@unittest.skipIf(postgresql.psycopg2 is not None, "postgresql is installed.")
+class PostgresqlExceptionRaisedTest(unittest.TestCase):
+    def test_postgresql_usage_raise_an_error_if_postgresql_not_installed(self):
+        with self.assertRaises(ImportWarning):
+            postgresql.PostgreSQLClient()

--- a/cliquet/utils.py
+++ b/cliquet/utils.py
@@ -17,9 +17,13 @@ except ImportError:  # pragma: no cover
 try:
     import psycopg2  # NOQA
 except ImportError:  # pragma: no cover
-    from psycopg2cffi import compat
-    compat.register()
-    import psycopg2  # NOQA
+    try:
+        from psycopg2cffi import compat
+    except ImportError:
+        psycopg2 = None
+    else:
+        compat.register()
+        import psycopg2  # NOQA
 
 from cornice import cors
 from colander import null

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,pypy,flake8
+envlist = py27,py34,pypy,py27-raw,flake8
 
 [testenv]
 commands =
@@ -28,6 +28,17 @@ deps =
     statsd
     webtest
     newrelic
+    werkzeug
+
+[testenv:py27-raw]
+commands =
+    python --version
+    nosetests cliquet {posargs}
+deps =
+    coverage
+    mock
+    nose
+    webtest
     werkzeug
 
 [testenv:pypy]


### PR DESCRIPTION
This enable kinto to be installed without psycopg:

 - [x] Add a travis run with bare cliquet (without monitoring nor postgresql)
 - [x] Fail if using postgresql backend without having installed postgresql with a proper explaination
