### PR TITLE
Specify database encoding and timezone in doc

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -65,7 +65,9 @@ Currently, running the complete test suite implies to run every type of backend.
 That means:
 
 * Run Redis on ``localhost:6379``
-* Run a PostgreSQL ``testdb`` database on ``localhost:5432`` with user ``postgres/postgres``
+* Run a PostgreSQL 9.4 ``testdb`` database on ``localhost:5432`` with user
+  ``postgres/postgres``. The database encoding should be ``UTF-8``, and the
+  database timezone should be ``UTC``.
 
 ::
 

--- a/docs/reference/installation.rst
+++ b/docs/reference/installation.rst
@@ -152,6 +152,14 @@ if ran by the ``postgres`` system user. The following command will assign it:
 
     sudo -u postgres psql -c "ALTER USER postgres PASSWORD 'postgres';"
 
+Cliquet requires that ``UTC`` be used as the database timezone, and that
+``UTF-8`` as the database encoding. You can for example use the following
+commands to create a database named ``testdb`` with the appropriate timezone
+and encoding::
+
+    sudo -u postgres psql -c "ALTER ROLE postgres SET TIMEZONE TO 'UTC';"
+    sudo -u postgres psql -c "CREATE DATABASE testdb ENCODING 'UTF-8';"
+
 
 Server using Docker
 -------------------


### PR DESCRIPTION
Cliquet requires that `UTC` be used as the Postgres database timezone, and `UTF-8` as the encoding. This PR mentions this in the documentation.

I think the documentation still needs some love, I'll see if I can find time for more changes.