### PR TITLE
Filter collection records for guests (ref #354)

### DIFF
--- a/cliquet/authorization.py
+++ b/cliquet/authorization.py
@@ -138,10 +138,17 @@ class RouteFactory(object):
             object_id_match='*%s*' % object_id)
 
     def fetch_shared_records(self, principals):
-        self.shared_ids = self.get_shared_ids(principals=principals)
+        shared_ids = self.get_shared_ids(principals=principals)
+        self.shared_ids = [extract_object_id(shared_id)
+                           for shared_id in shared_ids]
         return self.shared_ids
 
 
 def get_object_id(object_uri):
     # Remove potential version prefix in URI.
     return re.sub(r'^(/v\d+)?', '', six.text_type(object_uri))
+
+
+def extract_object_id(object_id):
+    # XXX: Help needed: use something like route.matchdict.get('id').
+    return object_id.split('/')[-1]

--- a/cliquet/authorization.py
+++ b/cliquet/authorization.py
@@ -82,10 +82,6 @@ class RouteFactory(object):
         # Store service, resource, record and required permission.
         service = utils.current_service(request)
 
-        # Determine if current request hits a collection.
-        # XXX: this will fail if ViewSet.service_name is customized.
-        self.on_collection = service.name.endswith('-collection')
-
         is_on_resource = (service is not None and
                           hasattr(service, 'viewset') and
                           hasattr(service, 'resource'))
@@ -95,8 +91,9 @@ class RouteFactory(object):
             permission = None
             resource_name = None
             check_permission = None
-
+            on_collection = False
         else:
+            on_collection = getattr(service, "type", None) == "collection"
             object_id = get_object_id(request.path)
 
             # Decide what the required unbound permission is depending on the
@@ -132,6 +129,7 @@ class RouteFactory(object):
         self.required_permission = permission
         self.resource_name = resource_name
         self.check_permission = check_permission
+        self.on_collection = on_collection
 
         self.shared_ids = []
         self.get_shared_ids = functools.partial(

--- a/cliquet/authorization.py
+++ b/cliquet/authorization.py
@@ -145,8 +145,3 @@ class RouteFactory(object):
 def get_object_id(object_uri):
     # Remove potential version prefix in URI.
     return re.sub(r'^(/v\d+)?', '', six.text_type(object_uri))
-
-
-def extract_object_id(object_id):
-    # XXX: Help needed: use something like route.matchdict.get('id').
-    return object_id.split('/')[-1]

--- a/cliquet/permission/memory.py
+++ b/cliquet/permission/memory.py
@@ -26,13 +26,13 @@ class Memory(PermissionBase):
 
     def add_user_principal(self, user_id, principal):
         user_key = 'user:%s' % user_id
-        user_principals = self._store.get(user_key, set([]))
+        user_principals = self._store.get(user_key, set())
         user_principals.add(principal)
         self._store[user_key] = user_principals
 
     def remove_user_principal(self, user_id, principal):
         user_key = 'user:%s' % user_id
-        user_principals = self._store.get(user_key, set([]))
+        user_principals = self._store.get(user_key, set())
         try:
             user_principals.remove(principal)
         except KeyError:
@@ -45,18 +45,18 @@ class Memory(PermissionBase):
 
     def user_principals(self, user_id):
         user_key = 'user:%s' % user_id
-        members = self._store.get(user_key, set([]))
+        members = self._store.get(user_key, set())
         return members
 
     def add_principal_to_ace(self, object_id, permission, principal):
         permission_key = 'permission:%s:%s' % (object_id, permission)
-        object_permission_principals = self._store.get(permission_key, set([]))
+        object_permission_principals = self._store.get(permission_key, set())
         object_permission_principals.add(principal)
         self._store[permission_key] = object_permission_principals
 
     def remove_principal_from_ace(self, object_id, permission, principal):
         permission_key = 'permission:%s:%s' % (object_id, permission)
-        object_permission_principals = self._store.get(permission_key, set([]))
+        object_permission_principals = self._store.get(permission_key, set())
         try:
             object_permission_principals.remove(principal)
         except KeyError:
@@ -69,19 +69,20 @@ class Memory(PermissionBase):
 
     def object_permission_principals(self, object_id, permission):
         permission_key = 'permission:%s:%s' % (object_id, permission)
-        members = self._store.get(permission_key, set([]))
+        members = self._store.get(permission_key, set())
         return members
 
     def principals_accessible_objects(self, principals, permission,
                                       object_id_match=None):
+        principals = set(principals)
         if object_id_match is None:
             object_id_match = re.compile('.*')
         else:
             object_id_match = re.compile(object_id_match.replace('*', '.*'))
-        objects = set([])
+        objects = set()
         for key, value in self._store.items():
             if key.endswith(permission):
-                if len(set(principals) & value) > 0:
+                if len(principals & value) > 0:
                     object_id = key.split(':')[1]
                     if object_id_match.match(object_id):
                         objects.add(object_id)
@@ -93,7 +94,7 @@ class Memory(PermissionBase):
             keys = [(object_id, permission)]
         else:
             keys = get_bound_permissions(object_id, permission)
-        principals = set([])
+        principals = set()
         for obj_id, perm in keys:
             principals |= self.object_permission_principals(obj_id, perm)
         return principals

--- a/cliquet/permission/postgresql/__init__.py
+++ b/cliquet/permission/postgresql/__init__.py
@@ -147,7 +147,7 @@ class PostgreSQL(PostgreSQLClient, PermissionBase):
             perms = get_bound_permissions(object_id, permission)
 
         if not perms:
-            return set([])
+            return set()
 
         perms_values = ','.join(["('%s', '%s')" % p for p in perms])
         query = """

--- a/cliquet/permission/redis.py
+++ b/cliquet/permission/redis.py
@@ -85,7 +85,7 @@ class Redis(PermissionBase):
             object_id_match = '*'
         key_pattern = 'permission:%s:%s' % (object_id_match, permission)
 
-        objects = set([])
+        objects = set()
         keys = self._client.scan_iter(match=key_pattern)
         for key in keys:
             authorized = self._decode_set(self._client.smembers(key))
@@ -106,7 +106,7 @@ class Redis(PermissionBase):
         keys = ['permission:%s:%s' % key for key in keys]
         if keys:
             return self._decode_set(self._client.sunion(*list(keys)))
-        return set([])
+        return set()
 
 
 def load_from_config(config):

--- a/cliquet/resource.py
+++ b/cliquet/resource.py
@@ -1077,6 +1077,7 @@ class ProtectedResource(BaseResource):
 
         # XXX: find more elegant approach to add custom filters.
         ids = self.context.shared_ids
+
         if ids:
             filter_by_id = Filter(self.collection.id_field, ids, COMPARISON.IN)
             filters.insert(0, filter_by_id)

--- a/cliquet/resource.py
+++ b/cliquet/resource.py
@@ -1074,18 +1074,9 @@ class ProtectedResource(BaseResource):
     def _extract_filters(self, queryparams=None):
         filters = super(ProtectedResource, self)._extract_filters(queryparams)
 
-        # Guest wants her records.
-        # guest_principals is set in Authorization policy permits().
-        # XXX: better request.effective_principals + context.prefixed_userid ?
-        guest_principals = getattr(self.context, 'guest_principals', [])
-        if guest_principals:
-            permission_backend = self.request.registry.permission
-            query_ids = permission_backend.principals_accessible_objects
-            permission = self.context.required_permission
-            ids = query_ids(guest_principals, permission)
-            # Since object_ids are URIs, must extract records ids (e.g. UUID)
-            ids = [authorization.extract_object_id(obj_id) for obj_id in ids]
-
+        # XXX: find more elegant approach to add custom filters.
+        ids = self.context.shared_ids
+        if ids:
             filter_by_id = Filter(self.collection.id_field, ids, COMPARISON.IN)
             filters.insert(0, filter_by_id)
 

--- a/cliquet/resource.py
+++ b/cliquet/resource.py
@@ -255,6 +255,7 @@ def register_resource(resource_cls, settings=None, viewset=None, depth=1,
         service.collection_path = viewset.collection_path.format(
             **path_formatters)
         service.record_path = viewset.record_path.format(**path_formatters)
+        service.type = endpoint_type
 
         methods = getattr(viewset, '%s_methods' % endpoint_type)
         for method in methods:

--- a/cliquet/tests/resource/test_object_permissions.py
+++ b/cliquet/tests/resource/test_object_permissions.py
@@ -160,7 +160,7 @@ class GuestCollectionListTest(PermissionTest):
         self.permission.add_principal_to_ace(uri2, 'read', 'group')
         self.permission.add_principal_to_ace(uri3, 'read', 'jean-louis')
 
-        self.resource.context.guest_principals = ['fxa:user', 'group']
+        self.resource.context.shared_ids = [record1['id'], record2['id']]
 
     def test_collection_is_filtered_for_current_guest(self):
         result = self.resource.collection_get()
@@ -173,12 +173,12 @@ class GuestCollectionListTest(PermissionTest):
         self.assertEqual(len(result['data']), 1)
 
     def test_guest_collection_is_empty_if_no_record_is_shared(self):
-        self.resource.context.guest_principals = ['tata lili']
+        self.resource.context.shared_ids = ['tata lili']
         result = self.resource.collection_get()
         self.assertEqual(len(result['data']), 0)
 
     def test_permission_backend_is_not_queried_if_not_guest(self):
-        delattr(self.resource.context, 'guest_principals')
+        self.resource.context.shared_ids = []
         self.resource.request.registry.permission = None  # would fail!
         result = self.resource.collection_get()
         self.assertEqual(len(result['data']), 3)
@@ -205,7 +205,7 @@ class GuestCollectionDeleteTest(PermissionTest):
         self.permission.add_principal_to_ace(uri3, 'write', 'group')
         self.permission.add_principal_to_ace(uri4, 'write', 'jean-louis')
 
-        self.resource.context.guest_principals = ['fxa:user', 'group']
+        self.resource.context.shared_ids = [record2['id'], record3['id']]
         self.resource.request.method = 'DELETE'
 
     def get_request(self):
@@ -227,7 +227,7 @@ class GuestCollectionDeleteTest(PermissionTest):
         self.assertEqual(len(records), 3)
 
     def test_guest_cannot_delete_records_if_not_allowed(self):
-        self.resource.context.guest_principals = ['tata lili']
+        self.resource.context.shared_ids = ['tata lili']
         result = self.resource.collection_delete()
         self.assertEqual(len(result['data']), 0)
         records, _ = self.resource.collection.get_records()

--- a/cliquet/tests/test_permission.py
+++ b/cliquet/tests/test_permission.py
@@ -109,7 +109,7 @@ class BaseTestPermission(object):
         principal = 'bar'
         self.permission.remove_user_principal(user_id, principal)
         retrieved = self.permission.user_principals(user_id)
-        self.assertEquals(retrieved, set([]))
+        self.assertEquals(retrieved, set())
 
     def test_can_add_a_principal_to_an_object_permission(self):
         object_id = 'foo'
@@ -152,7 +152,7 @@ class BaseTestPermission(object):
                                                   principal)
         retrieved = self.permission.object_permission_principals(
             object_id, permission)
-        self.assertEquals(retrieved, set([]))
+        self.assertEquals(retrieved, set())
 
     def test_can_remove_an_unexisting_principal_to_an_object_permission(self):
         object_id = 'foo'
@@ -209,16 +209,16 @@ class BaseTestPermission(object):
 
     def test_object_permission_authorized_principals_handles_empty_set(self):
         object_id = 'foo'
-        permissions = set([])
+        permissions = set()
         user_id = 'bar'
         self.permission.add_principal_to_ace(object_id, 'write', user_id)
         principals = self.permission.object_permission_authorized_principals(
             object_id, 'read', lambda object_id, permission: permissions)
-        self.assertEquals(principals, set([]))
+        self.assertEquals(principals, set())
 
     def test_check_permissions_handles_empty_set(self):
         object_id = 'foo'
-        permissions = set([])
+        permissions = set()
         principal = 'bar'
         self.permission.add_principal_to_ace(object_id, 'write', principal)
         permits = self.permission.check_permission(

--- a/cliquet/tests/testapp/views.py
+++ b/cliquet/tests/testapp/views.py
@@ -15,6 +15,9 @@ class Mushroom(resource.BaseResource):
 class Toadstool(resource.ProtectedResource):
     mapping = MushroomSchema()
 
+    def get_parent_id(self, request):
+        return "foobar"
+
 
 @resource.register()
 class Moisture(resource.ProtectedResource):

--- a/cliquet/views/errors.py
+++ b/cliquet/views/errors.py
@@ -19,8 +19,6 @@ def cors(view):
     def wrap_view(request, *args, **kwargs):
         response = view(request, *args, **kwargs)
 
-        print "cors"
-
         # We need to re-apply the CORS checks done by Cornice, since we're
         # recreating the response from scratch.
         return reapply_cors(request, response)
@@ -53,7 +51,6 @@ def authorization_required(request):
 @cors
 def page_not_found(request):
     """Return a JSON 404 error response."""
-    print "404"
     if request.path.startswith('/' + request.registry.route_prefix):
         errno = ERRORS.MISSING_RESOURCE
         error_msg = "The resource your are looking for could not be found."

--- a/cliquet/views/errors.py
+++ b/cliquet/views/errors.py
@@ -19,6 +19,8 @@ def cors(view):
     def wrap_view(request, *args, **kwargs):
         response = view(request, *args, **kwargs)
 
+        print "cors"
+
         # We need to re-apply the CORS checks done by Cornice, since we're
         # recreating the response from scratch.
         return reapply_cors(request, response)
@@ -51,6 +53,7 @@ def authorization_required(request):
 @cors
 def page_not_found(request):
     """Return a JSON 404 error response."""
+    print "404"
     if request.path.startswith('/' + request.registry.route_prefix):
         errno = ERRORS.MISSING_RESOURCE
         error_msg = "The resource your are looking for could not be found."


### PR DESCRIPTION
I decided to follow the first strategy described in #354. Even though the one I prefer is the number 5. But for me hacking some code is a good way to start thinking about it.

* [x] Add a IN filter in storage
* [x] Query the permissions backend to obtain the list of object ids
* [x] Add some hack in authorization to let guest list the collections
* [ ] Make sure normal resources are not affected (**currently open door**), should be only ProtectedResources
* [x] Filter by permissions (by collection name)
* [ ] Think about parent_id etc.
* [ ] Add some functional tests to make sure use cases described in #354 are covered

I take reviews for:
* vetos against this strategy (*i.e. give the feature but does not scale*)
* alternative solutions in the authorization code :)
