### PR TITLE
Fix lost querystring during version redirection (fixes #364)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ This document describes changes between each past release.
 - Default resources do not hit the permission backend anymore
 - Default viewset was split and does not handle permissions anymore (fixes #322)
 - Permissions on views is now set only on resources
+- Fix lost querystring during version redirection (fixes #364)
 
 
 2.2.1 (2015-07-06)

--- a/cliquet/initialization.py
+++ b/cliquet/initialization.py
@@ -58,8 +58,11 @@ def setup_version_redirection(config):
         return
 
     def _redirect_to_version_view(request):
-        raise HTTPTemporaryRedirect(
-            '/%s/%s' % (route_prefix, request.matchdict['path']))
+        path = request.matchdict['path']
+        querystring = request.url[(request.url.rindex(request.path) +
+                                   len(request.path)):]
+        redirect = '/%s/%s%s' % (route_prefix, path, querystring)
+        raise HTTPTemporaryRedirect(redirect)
 
     # Disable the route prefix passed by the app.
     config.route_prefix = None

--- a/cliquet/tests/test_views_errors.py
+++ b/cliquet/tests/test_views_errors.py
@@ -155,3 +155,8 @@ class RedirectViewTest(FormattedErrorMixin, BaseWebTest, unittest.TestCase):
         })
 
         app.get('/', status=404)
+
+    def test_querystring_is_preserved_during_redirection(self):
+        response = self.app.get('/home/articles?_since=42')
+        self.assertEqual(response.location,
+                         'http://localhost/v0/home/articles?_since=42')


### PR DESCRIPTION
A small fix to check if TravisCI fails like for #372 