### PR TITLE
Expose the authenticated_userid in an endpoint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,10 +6,15 @@ This document describes changes between each past release.
 2.4 (unreleased)
 ----------------
 
+**New features**
+
+- Provide the userid when calling the hello page with an Authorization
+  header. (#319)
+
 **Bug fixes**
 
-- Fix crash on hello view when application is not deployed from Git repository
-  (fixes #382)
+- Fix crash on hello view when application is not deployed from Git
+  repository (fixes #382)
 
 
 2.3 (2015-07-13)

--- a/cliquet/tests/test_views_hello.py
+++ b/cliquet/tests/test_views_hello.py
@@ -45,3 +45,14 @@ class HelloViewTest(BaseWebTest, unittest.TestCase):
         response = self.app.get('/')
         settings = response.json['settings']
         self.assertIn('cliquet.paginate_by', settings)
+
+    def test_if_user_not_authenticated_no_userid_provided(self):
+        response = self.app.get('/')
+        self.assertNotIn('userid', response.json)
+
+    def test_if_user_authenticated_userid_is_provided(self):
+        response = self.app.get('/', headers=self.headers)
+        self.assertIn('userid', response.json)
+        self.assertTrue(
+            response.json['userid'].startswith('basicauth:'),
+            '"%s" does not starts with "basicauth:"' % response.json['userid'])

--- a/cliquet/views/hello.py
+++ b/cliquet/views/hello.py
@@ -33,6 +33,10 @@ def get_hello(request):
     public_settings = request.registry.public_settings
     data['settings'] = {k: settings[k] for k in public_settings}
 
+    prefixed_userid = getattr(request, 'prefixed_userid', None)
+    if prefixed_userid:
+        data['userid'] = prefixed_userid
+
     return data
 
 

--- a/docs/api/utilities.rst
+++ b/docs/api/utilities.rst
@@ -16,6 +16,8 @@ The returned value is a JSON mapping containing:
 - ``documentation``: The url to the service documentation. (this document!)
 - ``settings``: a mapping with the values of relevant public settings for clients
     - ``cliquet.batch_max_requests``: Number of requests that can be made in a batch request.
+- ``userid``: The connected perso user id. The field is not present
+  when no Authorization header is provided.
 
 
 GET /__heartbeat__


### PR DESCRIPTION
Clients need to know what's their userid is, in order to set and manage permission.

We should expose that in either an extra endpoint or the root one.
We may use the same endpoint as #318 in case we decide to create one.