### PR TITLE
Cliquet storage should be able to remove tombstones

### DIFF
--- a/cliquet/storage/__init__.py
+++ b/cliquet/storage/__init__.py
@@ -154,7 +154,7 @@ class StorageBase(object):
         raise NotImplementedError
 
     def delete(self, collection_id, parent_id, object_id,
-               id_field=DEFAULT_ID_FIELD, with_deleted=True,
+               with_deleted=True, id_field=DEFAULT_ID_FIELD,
                modified_field=DEFAULT_MODIFIED_FIELD,
                deleted_field=DEFAULT_DELETED_FIELD,
                auth=None):
@@ -175,6 +175,7 @@ class StorageBase(object):
         :param str parent_id: the collection parent.
 
         :param str object_id: unique identifier of the object
+        :param bool with_deleted: track deleted record with a tombstone
 
         :returns: the deleted object, with minimal set of attributes.
         :rtype: dict
@@ -182,7 +183,7 @@ class StorageBase(object):
         raise NotImplementedError
 
     def delete_all(self, collection_id, parent_id, filters=None,
-                   id_field=DEFAULT_ID_FIELD, with_deleted=True,
+                   with_deleted=True, id_field=DEFAULT_ID_FIELD,
                    modified_field=DEFAULT_MODIFIED_FIELD,
                    deleted_field=DEFAULT_DELETED_FIELD,
                    auth=None):
@@ -193,6 +194,7 @@ class StorageBase(object):
 
         :param filters: Optionnally filter the objects to delete.
         :type filters: list of :class:`cliquet.storage.Filter`
+        :param bool with_deleted: track deleted records with a tombstone
 
         :returns: the list of deleted objects, with minimal set of attributes.
         :rtype: list of dict

--- a/cliquet/storage/__init__.py
+++ b/cliquet/storage/__init__.py
@@ -199,17 +199,17 @@ class StorageBase(object):
         """
         raise NotImplementedError
 
-    def delete_tombstones(self, collection_id, parent_id, before=None,
-                          id_field=DEFAULT_ID_FIELD,
-                          modified_field=DEFAULT_MODIFIED_FIELD,
-                          auth=None):
-        """Delete all tombstones for deleted object in this `collection_id`
+    def purge_deleted(self, collection_id, parent_id, before=None,
+                      id_field=DEFAULT_ID_FIELD,
+                      modified_field=DEFAULT_MODIFIED_FIELD,
+                      auth=None):
+        """Delete all deleted object tombstones in this `collection_id`
         for this `parent_id`.
 
         :param str collection_id: the collection id.
         :param str parent_id: the collection parent.
 
-        :param int before: Optionnally elete tombstones older than it.
+        :param int before: Optionnal timestamp to limit deletion (exclusive)
 
         :returns: The number of deleted objects.
         :rtype: int

--- a/cliquet/storage/__init__.py
+++ b/cliquet/storage/__init__.py
@@ -199,6 +199,24 @@ class StorageBase(object):
         """
         raise NotImplementedError
 
+    def delete_tombstones(self, collection_id, parent_id, before=None,
+                          id_field=DEFAULT_ID_FIELD,
+                          modified_field=DEFAULT_MODIFIED_FIELD,
+                          auth=None):
+        """Delete all tombstones for deleted object in this `collection_id`
+        for this `parent_id`.
+
+        :param str collection_id: the collection id.
+        :param str parent_id: the collection parent.
+
+        :param int before: Optionnally elete tombstones older than it.
+
+        :returns: The number of deleted objects.
+        :rtype: int
+
+        """
+        raise NotImplementedError
+
     def get_all(self, collection_id, parent_id, filters=None, sorting=None,
                 pagination_rules=None, limit=None, include_deleted=False,
                 id_field=DEFAULT_ID_FIELD,

--- a/cliquet/storage/__init__.py
+++ b/cliquet/storage/__init__.py
@@ -154,7 +154,7 @@ class StorageBase(object):
         raise NotImplementedError
 
     def delete(self, collection_id, parent_id, object_id,
-               id_field=DEFAULT_ID_FIELD,
+               id_field=DEFAULT_ID_FIELD, with_deleted=True,
                modified_field=DEFAULT_MODIFIED_FIELD,
                deleted_field=DEFAULT_DELETED_FIELD,
                auth=None):
@@ -182,7 +182,7 @@ class StorageBase(object):
         raise NotImplementedError
 
     def delete_all(self, collection_id, parent_id, filters=None,
-                   id_field=DEFAULT_ID_FIELD,
+                   id_field=DEFAULT_ID_FIELD, with_deleted=True,
                    modified_field=DEFAULT_MODIFIED_FIELD,
                    deleted_field=DEFAULT_DELETED_FIELD,
                    auth=None):

--- a/cliquet/storage/memory.py
+++ b/cliquet/storage/memory.py
@@ -24,7 +24,7 @@ class MemoryBasedStorage(StorageBase):
         pass
 
     def delete_all(self, collection_id, parent_id, filters=None,
-                   id_field=DEFAULT_ID_FIELD,
+                   id_field=DEFAULT_ID_FIELD, with_deleted=True,
                    modified_field=DEFAULT_MODIFIED_FIELD,
                    deleted_field=DEFAULT_DELETED_FIELD,
                    auth=None):
@@ -34,7 +34,7 @@ class MemoryBasedStorage(StorageBase):
                                       modified_field=modified_field,
                                       deleted_field=deleted_field)
         deleted = [self.delete(collection_id, parent_id, r[id_field],
-                               id_field=id_field,
+                               id_field=id_field, with_deleted=with_deleted,
                                modified_field=modified_field,
                                deleted_field=deleted_field)
                    for r in records]
@@ -221,7 +221,7 @@ class Memory(MemoryBasedStorage):
         return record
 
     def delete(self, collection_id, parent_id, object_id,
-               id_field=DEFAULT_ID_FIELD,
+               id_field=DEFAULT_ID_FIELD, with_deleted=True,
                modified_field=DEFAULT_MODIFIED_FIELD,
                deleted_field=DEFAULT_DELETED_FIELD,
                auth=None):
@@ -233,7 +233,9 @@ class Memory(MemoryBasedStorage):
                                              existing)
 
         # Add to deleted items, remove from store.
-        self._cemetery[collection_id][parent_id][object_id] = existing.copy()
+        if with_deleted:
+            deleted = existing.copy()
+            self._cemetery[collection_id][parent_id][object_id] = deleted
         self._store[collection_id][parent_id].pop(object_id)
 
         return existing

--- a/cliquet/storage/memory.py
+++ b/cliquet/storage/memory.py
@@ -238,10 +238,10 @@ class Memory(MemoryBasedStorage):
 
         return existing
 
-    def delete_tombstones(self, collection_id, parent_id, before=None,
-                          id_field=DEFAULT_ID_FIELD,
-                          modified_field=DEFAULT_MODIFIED_FIELD,
-                          auth=None):
+    def purge_deleted(self, collection_id, parent_id, before=None,
+                      id_field=DEFAULT_ID_FIELD,
+                      modified_field=DEFAULT_MODIFIED_FIELD,
+                      auth=None):
         num_deleted = len(self._cemetery[collection_id][parent_id].keys())
         if before is not None:
             kept = {key: value for key, value in

--- a/cliquet/storage/memory.py
+++ b/cliquet/storage/memory.py
@@ -27,7 +27,7 @@ class MemoryBasedStorage(StorageBase):
                    id_field=DEFAULT_ID_FIELD,
                    modified_field=DEFAULT_MODIFIED_FIELD,
                    deleted_field=DEFAULT_DELETED_FIELD,
-                   auth=None, delete_tombstones=False):
+                   auth=None):
         records, count = self.get_all(collection_id, parent_id,
                                       filters=filters,
                                       id_field=id_field,
@@ -38,13 +38,6 @@ class MemoryBasedStorage(StorageBase):
                                modified_field=modified_field,
                                deleted_field=deleted_field)
                    for r in records]
-
-        if delete_tombstones:
-            self.delete_tombstones(collection_id, parent_id,
-                                   id_field=id_field,
-                                   modified_field=modified_field,
-                                   auth=auth)
-
         return deleted
 
     def strip_deleted_record(self, resource, parent_id, record,

--- a/cliquet/storage/postgresql/__init__.py
+++ b/cliquet/storage/postgresql/__init__.py
@@ -450,10 +450,10 @@ class PostgreSQL(PostgreSQLClient, StorageBase):
 
         return records
 
-    def delete_tombstones(self, collection_id, parent_id, before=None,
-                          id_field=DEFAULT_ID_FIELD,
-                          modified_field=DEFAULT_MODIFIED_FIELD,
-                          auth=None):
+    def purge_deleted(self, collection_id, parent_id, before=None,
+                      id_field=DEFAULT_ID_FIELD,
+                      modified_field=DEFAULT_MODIFIED_FIELD,
+                      auth=None):
         query = """
         DELETE
         FROM deleted
@@ -470,7 +470,7 @@ class PostgreSQL(PostgreSQLClient, StorageBase):
 
         if before is not None:
             safeholders['conditions_filter'] = (
-                'AND as_epoch(last_modified) < %%(before)s')
+                'AND as_epoch(last_modified) < %(before)s')
             placeholders['before'] = before
 
         with self.connect() as cursor:

--- a/cliquet/storage/postgresql/__init__.py
+++ b/cliquet/storage/postgresql/__init__.py
@@ -455,16 +455,11 @@ class PostgreSQL(PostgreSQLClient, StorageBase):
                           modified_field=DEFAULT_MODIFIED_FIELD,
                           auth=None):
         query = """
-        WITH deleted_records AS (
-            DELETE
-            FROM deleted
-            WHERE parent_id = %%(parent_id)s
-              AND collection_id = %%(collection_id)s
-              %(conditions_filter)s
-            RETURNING id
-        )
-        SELECT COUNT(*) as deleted FROM deleted_records
-        RETURNING deleted;
+        DELETE
+        FROM deleted
+        WHERE parent_id = %%(parent_id)s
+          AND collection_id = %%(collection_id)s
+          %(conditions_filter)s;
         """
         id_field = id_field or self.id_field
         modified_field = modified_field or self.modified_field
@@ -480,9 +475,8 @@ class PostgreSQL(PostgreSQLClient, StorageBase):
 
         with self.connect() as cursor:
             cursor.execute(query % safeholders, placeholders)
-            result = cursor.fetchone()
 
-        return result['deleted']
+        return cursor.rowcount
 
     def get_all(self, collection_id, parent_id, filters=None, sorting=None,
                 pagination_rules=None, limit=None, include_deleted=False,

--- a/cliquet/storage/postgresql/__init__.py
+++ b/cliquet/storage/postgresql/__init__.py
@@ -407,7 +407,7 @@ class PostgreSQL(PostgreSQLClient, StorageBase):
                    id_field=DEFAULT_ID_FIELD,
                    modified_field=DEFAULT_MODIFIED_FIELD,
                    deleted_field=DEFAULT_DELETED_FIELD,
-                   auth=None, delete_tombstones=False):
+                   auth=None):
         query = """
         WITH deleted_records AS (
             DELETE
@@ -447,12 +447,6 @@ class PostgreSQL(PostgreSQLClient, StorageBase):
             record[modified_field] = result['last_modified']
             record[deleted_field] = True
             records.append(record)
-
-        if delete_tombstones:
-            self.delete_tombstones(collection_id, parent_id,
-                                   id_field=id_field,
-                                   modified_field=modified_field,
-                                   auth=auth)
 
         return records
 

--- a/cliquet/storage/redis.py
+++ b/cliquet/storage/redis.py
@@ -232,11 +232,12 @@ class Redis(MemoryBasedStorage):
         else:
             to_remove = [d['id'] for d in deleted]
 
-        with self._client.pipeline() as pipe:
-            pipe.delete(*['{0}.{1}.{2}.deleted'.format(
-                collection_id, parent_id, _id) for _id in to_remove])
-            pipe.srem(deleted_ids, *to_remove)
-            pipe.execute()
+        if len(to_remove) > 0:
+            with self._client.pipeline() as pipe:
+                pipe.delete(*['{0}.{1}.{2}.deleted'.format(
+                    collection_id, parent_id, _id) for _id in to_remove])
+                pipe.srem(deleted_ids, *to_remove)
+                pipe.execute()
         number_deleted = len(to_remove)
         return number_deleted
 

--- a/cliquet/tests/test_storage.py
+++ b/cliquet/tests/test_storage.py
@@ -543,12 +543,36 @@ class DeletedRecordsTest(object):
 
     def test_delete_all_keeps_track_of_deleted_records(self):
         filters = self._get_last_modified_filters()
-        self.create_and_delete_record()
+        record = {'challenge': 'accepted'}
+        record = self.create_record(record)
         self.storage.delete_all(**self.storage_kw)
         records, count = self.storage.get_all(filters=filters,
                                               include_deleted=True,
                                               **self.storage_kw)
         self.assertEqual(len(records), 1)
+        self.assertEqual(count, 0)
+
+    def test_delete_all_can_delete_without_deleted_items(self):
+        filters = self._get_last_modified_filters()
+        record = {'challenge': 'accepted'}
+        record = self.create_record(record)
+        self.storage.delete_all(with_deleted=False, **self.storage_kw)
+        records, count = self.storage.get_all(filters=filters,
+                                              include_deleted=True,
+                                              **self.storage_kw)
+        self.assertEqual(len(records), 0)
+        self.assertEqual(count, 0)
+
+    def test_delete_can_delete_without_deleted_items(self):
+        filters = self._get_last_modified_filters()
+        record = {'challenge': 'accepted'}
+        record = self.create_record(record)
+        self.storage.delete(object_id=record['id'], with_deleted=False,
+                            **self.storage_kw)
+        records, count = self.storage.get_all(filters=filters,
+                                              include_deleted=True,
+                                              **self.storage_kw)
+        self.assertEqual(len(records), 0)
         self.assertEqual(count, 0)
 
     def test_delete_all_deletes_records(self):

--- a/cliquet/tests/test_storage.py
+++ b/cliquet/tests/test_storage.py
@@ -601,6 +601,10 @@ class DeletedRecordsTest(object):
         self.assertEqual(count, 0)
         self.assertEqual(len(records), 0)
 
+    def test_purge_deleted_works_when_no_tombstones(self):
+        num_removed = self.storage.purge_deleted(**self.storage_kw)
+        self.assertEqual(num_removed, 0)
+
     def test_purge_deleted_remove_with_before_remove_olders_exclusive(self):
         older = self.create_record()
         newer = self.create_record()

--- a/cliquet/tests/test_storage.py
+++ b/cliquet/tests/test_storage.py
@@ -566,17 +566,6 @@ class DeletedRecordsTest(object):
         _, count = self.storage.get_all(**self.storage_kw)
         self.assertEqual(count, 1)
 
-    def test_delete_all_can_remove_tombstones(self):
-        self.create_record()
-        stored = self.create_record()
-        self.storage.delete(object_id=stored['id'], **self.storage_kw)
-        self.storage.delete_all(delete_tombstones=True, **self.storage_kw)
-
-        records, count = self.storage.get_all(include_deleted=True,
-                                              **self.storage_kw)
-        self.assertEqual(len(records), 0)
-        self.assertEqual(count, 0)
-
     def test_delete_tombstones_remove_all_tombstones(self):
         self.create_record()
         self.create_record()

--- a/docs/reference/glossary.rst
+++ b/docs/reference/glossary.rst
@@ -43,9 +43,9 @@ Glossary
 
     tombstone
     tombstones
-        When a record is deleted in a resource, a tombstone is created to let remote
-        clients know about the deletion. Only the id and the last_modified field are kept,
-        other information are really deleted.
+        When a record is deleted in a resource, a tombstone is created to keep
+        track of the deletion when polling for changes. A tombstone only contains
+        the ``id`` and ``last_modified`` fields, everything else is really deleted.
 
     principal
     principals

--- a/docs/reference/glossary.rst
+++ b/docs/reference/glossary.rst
@@ -41,6 +41,12 @@ Glossary
         the resources you defined; For one resource there are two objects: resource's
         collection and resource's records.
 
+    tombstone
+    tombstones
+        When a record is deleted in a resource, a tombstone is created to let remote
+        clients know about the deletion. Only the id and the last_modified field are kept,
+        other information are really deleted.
+
     principal
     principals
         An entity that can be authenticated. Principals can be individual people,


### PR DESCRIPTION
Refs mozilla-services/kinto#136

At the moment, delete_all() remove all objects and create tombstones, we should be able to pass a parameter ``delete_tombstones=True`` to also remove tombstones.