### PR TITLE
Plug get_bound_permissions for partial collections

### DIFF
--- a/cliquet/permission/__init__.py
+++ b/cliquet/permission/__init__.py
@@ -77,7 +77,8 @@ class PermissionBase(object):
         raise NotImplementedError
 
     def principals_accessible_objects(self, principals, permission,
-                                      object_id_match=None):
+                                      object_id_match=None,
+                                      get_bound_permissions=None):
         """Return the list of objects id where the specified `principals`
         have the specified `permission`.
 
@@ -85,6 +86,9 @@ class PermissionBase(object):
         :param str permission: The permission to query.
         :param str object_id_match: Filter object ids based on a pattern
             (e.g. ``'*articles*'``).
+        :param function get_bound_permissions:
+            The methods to call in order to generate the list of permission to
+            verify against. (ie: if you can write, you can read)
         :returns: The list of object ids
         :rtype: set
 

--- a/cliquet/permission/memory.py
+++ b/cliquet/permission/memory.py
@@ -76,16 +76,16 @@ class Memory(PermissionBase):
                                       object_id_match=None,
                                       get_bound_permissions=None):
         principals = set(principals)
+        if object_id_match is None:
+            object_id_match = '*'
 
         if get_bound_permissions is None:
-            if object_id_match is None:
-                object_id_match = '*'
             object_id_match = object_id_match.replace('*', '.*')
             keys = [(re.compile(object_id_match), permission)]
         else:
             keys = get_bound_permissions(object_id_match, permission)
-            keys = [(re.compile(obj_id.replace('*', '.*')), p)
-                    for (obj_id, p) in keys]
+            keys = [(re.compile(obj_id.replace('*', '.*')), p) for (obj_id, p)
+                    in keys if obj_id.endswith(object_id_match)]
 
         objects = set()
         for obj_id, perm in keys:

--- a/cliquet/permission/postgresql/__init__.py
+++ b/cliquet/permission/postgresql/__init__.py
@@ -167,25 +167,34 @@ class PostgreSQL(PostgreSQLClient, PermissionBase):
                                       object_id_match=None,
                                       get_bound_permissions=None):
         placeholders = {'permission': permission}
-        if object_id_match is None:
-            object_id_conditions = ['true']
 
+        if get_bound_permissions is None:
+            if object_id_match is None:
+                object_id_match = '*'
+            perms = [(object_id_match, permission)]
         else:
-            object_id_match = object_id_match.replace('*', '%%')
-            object_id_conditions = ["object_id LIKE %(object_id_match)s"]
-            placeholders['object_id_match'] = object_id_match
+            perms = get_bound_permissions(object_id_match, permission)
 
+        perms = [(o.replace('*', '.*'), p) for (o, p) in perms]
+        perms_values = ','.join(["('%s', '%s')" % p for p in perms])
         principals_values = ','.join(["('%s')" % p for p in principals])
         query = """
-        WITH user_principals AS (
-          VALUES %s
+        WITH required_perms AS (
+          VALUES %(perms)s
+        ),
+        user_principals AS (
+          VALUES %(principals)s
         )
         SELECT object_id
-          FROM user_principals JOIN access_control_entries
-            ON (principal = column1)
-         WHERE permission = %%(permission)s
-           AND %s;
-        """ % (principals_values, "AND ".join(object_id_conditions))
+          FROM access_control_entries
+            JOIN required_perms
+              ON (object_id ~ required_perms.column1 AND
+                  permission = required_perms.column2)
+            JOIN user_principals
+              ON (principal = user_principals.column1);
+        """ % dict(perms=perms_values,
+                   principals=principals_values)
+
         with self.connect() as cursor:
             cursor.execute(query, placeholders)
             results = cursor.fetchall()

--- a/cliquet/permission/postgresql/__init__.py
+++ b/cliquet/permission/postgresql/__init__.py
@@ -168,14 +168,16 @@ class PostgreSQL(PostgreSQLClient, PermissionBase):
                                       get_bound_permissions=None):
         placeholders = {'permission': permission}
 
+        if object_id_match is None:
+            object_id_match = '*'
+
         if get_bound_permissions is None:
-            if object_id_match is None:
-                object_id_match = '*'
             perms = [(object_id_match, permission)]
         else:
             perms = get_bound_permissions(object_id_match, permission)
 
-        perms = [(o.replace('*', '.*'), p) for (o, p) in perms]
+        perms = [(o.replace('*', '.*'), p) for (o, p) in perms
+                 if o.endswith(object_id_match)]
         perms_values = ','.join(["('%s', '%s')" % p for p in perms])
         principals_values = ','.join(["('%s')" % p for p in principals])
         query = """

--- a/cliquet/permission/redis.py
+++ b/cliquet/permission/redis.py
@@ -80,7 +80,8 @@ class Redis(PermissionBase):
 
     @wrap_redis_error
     def principals_accessible_objects(self, principals, permission,
-                                      object_id_match=None):
+                                      object_id_match=None,
+                                      get_bound_permissions=None):
         if object_id_match is None:
             object_id_match = '*'
         key_pattern = 'permission:%s:%s' % (object_id_match, permission)

--- a/cliquet/tests/test_authorization.py
+++ b/cliquet/tests/test_authorization.py
@@ -80,6 +80,7 @@ class RouteFactoryTest(unittest.TestCase):
         self.assertIsNone(context.required_permission)
         self.assertIsNone(context.resource_name)
         self.assertIsNone(context.check_permission)
+        self.assertIsNone(context.get_shared_ids)
 
     def test_attributes_are_none_with_non_resource_requests(self):
         basic_service = object()
@@ -94,6 +95,7 @@ class RouteFactoryTest(unittest.TestCase):
         self.assertIsNone(context.required_permission)
         self.assertIsNone(context.resource_name)
         self.assertIsNone(context.check_permission)
+        self.assertIsNone(context.get_shared_ids)
 
     def test_route_factory_adds_allowed_principals_from_settings(self):
         with mock.patch('cliquet.utils.current_service') as current_service:
@@ -210,7 +212,9 @@ class GuestAuthorizationPolicyTest(unittest.TestCase):
             'record1', 'record2'])
         allowed = self.authz.permits(self.context, ['userid'], 'dynamic')
         self.context.fetch_shared_records.assert_called_with(
-            ['userid', 'basicauth:bob', 'basicauth_bob'])
+            'read',
+            ['userid', 'basicauth:bob', 'basicauth_bob'],
+            get_bound_permissions=mock.sentinel.get_bound_perms)
         self.assertTrue(allowed)
 
     def test_permits_does_not_return_true_if_not_collection(self):
@@ -229,5 +233,7 @@ class GuestAuthorizationPolicyTest(unittest.TestCase):
         self.context.fetch_shared_records = mock.MagicMock(return_value=[])
         allowed = self.authz.permits(self.context, ['userid'], 'dynamic')
         self.context.fetch_shared_records.assert_called_with(
-            ['userid', 'basicauth:bob', 'basicauth_bob'])
+            'read',
+            ['userid', 'basicauth:bob', 'basicauth_bob'],
+            get_bound_permissions=mock.sentinel.get_bound_perms)
         self.assertFalse(allowed)

--- a/cliquet/tests/test_permission.py
+++ b/cliquet/tests/test_permission.py
@@ -275,7 +275,7 @@ class BaseTestPermission(object):
         object_ids = self.permission.principals_accessible_objects(
             ['user1'],
             'read',
-            get_bound_permissions=lambda o, p: [('/url/a/id/1', 'write'),
+            get_bound_permissions=lambda o, p: [('/url/a/id/*', 'write'),
                                                 ('/url/a/id/*', 'read')])
         self.assertEquals(object_ids, set(['/url/a/id/1', '/url/a/id/2']))
 

--- a/cliquet/tests/test_permission.py
+++ b/cliquet/tests/test_permission.py
@@ -256,6 +256,29 @@ class BaseTestPermission(object):
             object_id_match='*url1*')
         self.assertEquals(object_ids, set(['/url1/id']))
 
+    def test_obtain_object_ids_with_get_bound_permissions(self):
+        self.permission.add_principal_to_ace('/url/a/id/1', 'write', 'user1')
+        self.permission.add_principal_to_ace('/url/a/id/2', 'read', 'user1')
+        self.permission.add_principal_to_ace('/url/_/id/2', 'read', 'user1')
+        object_ids = self.permission.principals_accessible_objects(
+            ['user1'],
+            'read',
+            object_id_match='/url/a/id/*',
+            get_bound_permissions=lambda o, p: [('/url/a/id/*', 'read'),
+                                                ('/url/a/id/*', 'write')])
+        self.assertEquals(object_ids, set(['/url/a/id/1', '/url/a/id/2']))
+
+    def test_obtain_object_ids_with_get_bound_permissions_without_match(self):
+        self.permission.add_principal_to_ace('/url/a/id/1', 'write', 'user1')
+        self.permission.add_principal_to_ace('/url/a/id/2', 'read', 'user1')
+        self.permission.add_principal_to_ace('/url/b/id/2', 'read', 'user1')
+        object_ids = self.permission.principals_accessible_objects(
+            ['user1'],
+            'read',
+            get_bound_permissions=lambda o, p: [('/url/a/id/1', 'write'),
+                                                ('/url/a/id/*', 'read')])
+        self.assertEquals(object_ids, set(['/url/a/id/1', '/url/a/id/2']))
+
 
 class MemoryPermissionTest(BaseTestPermission, unittest.TestCase):
     backend = memory_backend


### PR DESCRIPTION
Currently, partial collections only work with records on which the user has the same specific permission.

With this pull-request we plug the ``get_bound_permission`` in order to obtain the list of accessible object ids from the permission backend.

For Kinto, this mean that if a user has the ``write`` permission on a record, it will be appear in the corresponding collection with a ``GET`` (because in Kinto, write implies read).

* [x] Refactor code in resource and authorization
* [x] Handle get_bound_permission response in Memory permission backend
* [x] Handle in Postgresql
* [x] Handle in Redis
