### PR TITLE
Contributors list in documentation?

### DIFF
--- a/cliquet_docs/contributing.rst
+++ b/cliquet_docs/contributing.rst
@@ -136,6 +136,7 @@ Step 1
 - Update ``CHANGELOG.rst``
 - Update version in ``docs/conf.py``
 - Known good versions of dependencies in ``requirements.txt``
+- Update ``CONTRIBUTORS.rst`` using: ``git shortlog -sne | awk '{$1=""; sub(" ", ""); print}'``
 
 .. code-block:: bash
 

--- a/cliquet_docs/contributing.rst
+++ b/cliquet_docs/contributing.rst
@@ -136,7 +136,7 @@ Step 1
 - Update ``CHANGELOG.rst``
 - Update version in ``docs/conf.py``
 - Known good versions of dependencies in ``requirements.txt``
-- Update ``CONTRIBUTORS.rst`` using: ``git shortlog -sne | awk '{$1=""; sub(" ", ""); print}'``
+- Update ``CONTRIBUTORS.rst`` using: ``git shortlog -sne | awk '{$1=""; sub(" ", ""); print}' | awk -F'<' '!x[$1]++' | awk -F'<' '!x[$2]++'``
 
 .. code-block:: bash
 


### PR DESCRIPTION
There is a hardcoded [list of contributors](https://cliquet.readthedocs.org/en/latest/contributors.html) in the documentation. This list may or may not line up with the [repo contributors graph](https://github.com/mozilla-services/cliquet/graphs/contributors), and in any case, poses problems in terms of maintenance.

I am curious who manages this list, and what the criteria are for inclusion (or not).  I'd also like to open bikeshed on whether this list should even be included at all - perhaps just a like to the contributors graph would be more honest (and sustainable in terms of maint)?  Either that or some sort of automated generation?