### PR TITLE
Add request bound data, shared with subrequests.

### DIFF
--- a/cliquet/__init__.py
+++ b/cliquet/__init__.py
@@ -40,6 +40,7 @@ DEFAULT_SETTINGS = {
     'cliquet.http_scheme': None,
     'cliquet.id_generator': 'cliquet.storage.generators.UUID4',
     'cliquet.initialization_sequence': (
+        'cliquet.initialization.setup_request_bound_data',
         'cliquet.initialization.setup_json_serializer',
         'cliquet.initialization.setup_logging',
         'cliquet.initialization.setup_storage',

--- a/cliquet/initialization.py
+++ b/cliquet/initialization.py
@@ -31,6 +31,16 @@ from pyramid.settings import asbool
 from pyramid_multiauth import MultiAuthPolicySelected
 
 
+def setup_request_bound_data(config):
+    """Attach custom data on request object, and share it with parent
+    requests during batch."""
+    def attach_bound_data(request):
+        parent = getattr(request, 'parent', None)
+        return parent.bound_data if parent else {}
+
+    config.add_request_method(attach_bound_data, name='bound_data', reify=True)
+
+
 def setup_json_serializer(config):
     # Monkey patch to use ujson
     webob.request.json = utils.json

--- a/cliquet/tests/test_views_batch.py
+++ b/cliquet/tests/test_views_batch.py
@@ -253,6 +253,12 @@ class BatchServiceTest(unittest.TestCase):
         result = self.post({'requests': [{'path': '/'}]})
         self.assertEqual(result['responses'][0]['path'], '/v0/')
 
+    def test_subrequests_have_parent_attribute(self):
+        self.request.path = '/batch'
+        self.post({'requests': [{'path': '/'}]})
+        subrequest, = self.request.invoke_subrequest.call_args[0]
+        self.assertEqual(subrequest.parent.path, '/batch')
+
     def test_subrequests_are_GET_by_default(self):
         self.post({'requests': [{'path': '/'}]})
         subrequest, = self.request.invoke_subrequest.call_args[0]

--- a/cliquet/views/batch.py
+++ b/cliquet/views/batch.py
@@ -91,6 +91,7 @@ def post_batch(request):
 
     for subrequest_spec in requests:
         subrequest = build_request(request, subrequest_spec)
+        subrequest.parent = request
 
         sublogger.bind(path=subrequest.path,
                        method=subrequest.method)


### PR DESCRIPTION
This allows to store any arbitrary data in a ``dict`` on the current request,
instead of setting custom attributes and testing their existance.

It is shared with subrequests during batch.

In the short term, this will allow us to reduce storage hits in batch
subrequests on the default bucket in Kinto.

In the long term, this will allow us to share storage connections accross
batch subrequests.

@Natim r?