### PR TITLE
Expose statsd client in the registry.

### DIFF
--- a/cliquet/initialization.py
+++ b/cliquet/initialization.py
@@ -223,9 +223,12 @@ def setup_cache(config):
 
 def setup_statsd(config):
     settings = config.get_settings()
+    config.registry.statsd = None
 
     if settings['cliquet.statsd_url']:
         client = statsd.load_from_config(config)
+
+        config.registry.statsd = client
 
         client.watch_execution_time(config.registry.cache, prefix='cache')
         client.watch_execution_time(config.registry.storage, prefix='storage')

--- a/cliquet/tests/test_initialization.py
+++ b/cliquet/tests/test_initialization.py
@@ -177,9 +177,23 @@ class StatsDConfigurationTest(unittest.TestCase):
         mocked.assert_not_called()
 
     @mock.patch('cliquet.statsd.Client')
+    def test_statsd_is_set_to_none_if_statsd_url_not_set(self, mocked):
+        self.config.add_settings({
+            'cliquet.statsd_url': None
+        })
+        initialization.setup_statsd(self.config)
+        self.assertEqual(self.config.registry.statsd, None)
+
+    @mock.patch('cliquet.statsd.Client')
     def test_statsd_is_called_if_statsd_url_is_set(self, mocked):
         initialization.setup_statsd(self.config)
         mocked.assert_called_with('host', 8080, 'cliquet')
+        self.assertEqual(self.config.registry.statsd, mocked.return_value)
+
+    @mock.patch('cliquet.statsd.Client')
+    def test_statsd_is_expose_in_the_registry_if_url_is_set(self, mocked):
+        initialization.setup_statsd(self.config)
+        self.assertEqual(self.config.registry.statsd, mocked.return_value)
 
     @mock.patch('cliquet.statsd.Client')
     def test_statsd_is_set_on_cache(self, mocked):

--- a/cliquet/tests/test_initialization.py
+++ b/cliquet/tests/test_initialization.py
@@ -188,7 +188,6 @@ class StatsDConfigurationTest(unittest.TestCase):
     def test_statsd_is_called_if_statsd_url_is_set(self, mocked):
         initialization.setup_statsd(self.config)
         mocked.assert_called_with('host', 8080, 'cliquet')
-        self.assertEqual(self.config.registry.statsd, mocked.return_value)
 
     @mock.patch('cliquet.statsd.Client')
     def test_statsd_is_expose_in_the_registry_if_url_is_set(self, mocked):


### PR DESCRIPTION
This is needed in order to add specific metrics in Syncto for instance. (https://github.com/mozilla-services/syncto/issues/18)