### PR TITLE
Add header to cache CORS preflight requests

### DIFF
--- a/cliquet/__init__.py
+++ b/cliquet/__init__.py
@@ -31,6 +31,7 @@ DEFAULT_SETTINGS = {
     'cliquet.cache_pool_size': 10,
     'cliquet.cache_url': '',
     'cliquet.cors_origins': '*',
+    'cliquet.cors_max_age': 3600,
     'cliquet.eos': None,
     'cliquet.eos_message': None,
     'cliquet.eos_url': None,
@@ -130,6 +131,9 @@ def includeme(config):
     Service.cors_origins = tuple(aslist(cors_origins))
     Service.default_cors_headers = ('Backoff', 'Retry-After', 'Alert',
                                     'Content-Length')
+    cors_max_age = settings['cliquet.cors_max_age']
+    Service.cors_max_age = int(cors_max_age) if cors_max_age else None
+
     Service.error_handler = lambda self, e: errors.json_error_handler(e)
 
     # Heartbeat registry.

--- a/cliquet/__init__.py
+++ b/cliquet/__init__.py
@@ -31,7 +31,7 @@ DEFAULT_SETTINGS = {
     'cliquet.cache_pool_size': 10,
     'cliquet.cache_url': '',
     'cliquet.cors_origins': '*',
-    'cliquet.cors_max_age': 3600,
+    'cliquet.cors_max_age_seconds': 3600,
     'cliquet.eos': None,
     'cliquet.eos_message': None,
     'cliquet.eos_url': None,
@@ -131,7 +131,7 @@ def includeme(config):
     Service.cors_origins = tuple(aslist(cors_origins))
     Service.default_cors_headers = ('Backoff', 'Retry-After', 'Alert',
                                     'Content-Length')
-    cors_max_age = settings['cliquet.cors_max_age']
+    cors_max_age = settings['cliquet.cors_max_age_seconds']
     Service.cors_max_age = int(cors_max_age) if cors_max_age else None
 
     Service.error_handler = lambda self, e: errors.json_error_handler(e)

--- a/cliquet/tests/resource/test_views_cors.py
+++ b/cliquet/tests/resource/test_views_cors.py
@@ -195,11 +195,11 @@ class CORSMaxAgeTest(BaseWebTest, unittest.TestCase):
         self.assertEqual(int(resp.headers['Access-Control-Max-Age']), 3600)
 
     def test_cors_max_age_can_be_specified_in_settings(self):
-        app = self.get_test_app({'cliquet.cors_max_age': '42'})
+        app = self.get_test_app({'cliquet.cors_max_age_seconds': '42'})
         resp = app.options('/', headers=self.headers)
         self.assertEqual(int(resp.headers['Access-Control-Max-Age']), 42)
 
     def test_cors_max_age_is_disabled_if_unset(self):
-        app = self.get_test_app({'cliquet.cors_max_age': ''})
+        app = self.get_test_app({'cliquet.cors_max_age_seconds': ''})
         resp = app.options('/', headers=self.headers)
         self.assertNotIn('Access-Control-Max-Age', resp.headers)

--- a/cliquet/tests/resource/test_views_cors.py
+++ b/cliquet/tests/resource/test_views_cors.py
@@ -179,3 +179,16 @@ class CORSExposeHeadersTest(BaseWebTest, unittest.TestCase):
     def test_present_on_unknown_url(self):
         self.assert_expose_headers('PUT_JSON', '/unknown', [
             'Alert', 'Backoff', 'Retry-After', 'Content-Length'], status=404)
+
+
+class CORSMaxAgeTest(BaseWebTest):
+    def setUp(self):
+        super(CORSMaxAgeTest, self).setUp()
+        self.headers.update({
+            'Origin': 'lolnet.org',
+            'Access-Control-Request-Method': 'GET'
+        })
+
+    def test_cors_max_age_is_3600_seconds_by_default(self):
+        resp = self.app.options('/', headers=self.headers)
+        self.assertEqual(int(resp.headers['Access-Control-Max-Age']), 3600)

--- a/cliquet/tests/resource/test_views_cors.py
+++ b/cliquet/tests/resource/test_views_cors.py
@@ -181,7 +181,7 @@ class CORSExposeHeadersTest(BaseWebTest, unittest.TestCase):
             'Alert', 'Backoff', 'Retry-After', 'Content-Length'], status=404)
 
 
-class CORSMaxAgeTest(BaseWebTest):
+class CORSMaxAgeTest(BaseWebTest, unittest.TestCase):
     def setUp(self):
         super(CORSMaxAgeTest, self).setUp()
         self.headers.update({
@@ -190,5 +190,16 @@ class CORSMaxAgeTest(BaseWebTest):
         })
 
     def test_cors_max_age_is_3600_seconds_by_default(self):
-        resp = self.app.options('/', headers=self.headers)
+        app = self.get_test_app()
+        resp = app.options('/', headers=self.headers)
         self.assertEqual(int(resp.headers['Access-Control-Max-Age']), 3600)
+
+    def test_cors_max_age_can_be_specified_in_settings(self):
+        app = self.get_test_app({'cliquet.cors_max_age': '42'})
+        resp = app.options('/', headers=self.headers)
+        self.assertEqual(int(resp.headers['Access-Control-Max-Age']), 42)
+
+    def test_cors_max_age_is_disabled_if_unset(self):
+        app = self.get_test_app({'cliquet.cors_max_age': ''})
+        resp = app.options('/', headers=self.headers)
+        self.assertNotIn('Access-Control-Max-Age', resp.headers)

--- a/cliquet_docs/reference/configuration.rst
+++ b/cliquet_docs/reference/configuration.rst
@@ -254,6 +254,20 @@ Basically, this will add both ``Cache-Control: max-age=3600`` and
 ``Expire: <server datetime + 1H>`` response headers to the ``GET`` responses.
 
 
+CORS
+----
+
+By default, CORS headers are cached by clients during 1H (``Access-Control-Max-Age``).
+
+The duration can be set from settings. If set to empty or to 0, the header
+is not sent to clients.
+
+.. code-block:: ini
+
+    cliquet.cors_max_age_seconds = 7200
+
+
+
 .. _configuration-authentication:
 
 Authentication

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 colander==1.0
-cornice==1.0.0
+cornice==1.1.0
 dealer==2.0.4
 iso8601==0.1.10
 PasteDeploy==1.5.2

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ installed_with_pypy = platform.python_implementation() == 'PyPy'
 
 REQUIREMENTS = [
     'colander',
-    'cornice >= 1.0',  # Disable request binding.
+    'cornice >= 1.1',  # Fix cache CORS
     'dealer',  # For git.revision
     'python-dateutil',
     'pyramid_multiauth >= 0.5',  # Pluggable authz


### PR DESCRIPTION
ref https://github.com/Kinto/kinto/issues/185

**Requires** https://github.com/mozilla-services/cornice/pull/338

* [x] Take cors max age from settings
* [x] Test app initialization with custom setting
