### PR TITLE
Expose public settings the way they are listed (according to their prefixes).

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ This document describes changes between each past release.
 2.9.0 (unreleased)
 ------------------
 
-- Expose public settings without prefix, expect if we explicitely want
+- Expose public settings without prefix, except if we explicitely want
   to expose cliquet.
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,8 +7,9 @@ This document describes changes between each past release.
 2.9.0 (unreleased)
 ------------------
 
-- Expose public settings without prefix, except if we explicitely want
-  to expose cliquet.
+- Expose public settings without prefix, except if we explicitely
+  configure public_settings to expose them (with ``cliquet.`` or
+  ``project_name.``) (refs #476)
 
 
 2.8.0 (2015-10-06)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,8 @@ This document describes changes between each past release.
 2.9.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Expose public settings without prefix, expect if we explicitely want
+  to expose cliquet.
 
 
 2.8.0 (2015-10-06)

--- a/cliquet/__init__.py
+++ b/cliquet/__init__.py
@@ -98,7 +98,7 @@ def includeme(config):
     config.registry.heartbeats = {}
 
     # Public settings registry.
-    config.registry.public_settings = {'cliquet.batch_max_requests'}
+    config.registry.public_settings = {'batch_max_requests'}
 
     # Setup components.
     for step in aslist(settings['initialization_sequence']):

--- a/cliquet/__init__.py
+++ b/cliquet/__init__.py
@@ -98,7 +98,7 @@ def includeme(config):
     config.registry.heartbeats = {}
 
     # Public settings registry.
-    config.registry.public_settings = {'batch_max_requests'}
+    config.registry.public_settings = {'cliquet.batch_max_requests'}
 
     # Setup components.
     for step in aslist(settings['initialization_sequence']):

--- a/cliquet/tests/test_views_hello.py
+++ b/cliquet/tests/test_views_hello.py
@@ -37,14 +37,15 @@ class HelloViewTest(BaseWebTest, unittest.TestCase):
     def test_public_settings_are_shown_in_view(self):
         response = self.app.get('/')
         settings = response.json['settings']
-        expected = {'myapp.batch_max_requests': 25}
+        expected = {'cliquet.batch_max_requests': 25,
+                    'batch_max_requests': 25}
         self.assertEqual(expected, settings)
 
     def test_public_settings_can_be_set_from_registry(self):
         self.app.app.registry.public_settings.add('myapp.paginate_by')
         response = self.app.get('/')
         settings = response.json['settings']
-        self.assertIn('myapp.paginate_by', settings)
+        self.assertIn('paginate_by', settings)
 
     def test_public_settings_can_be_set_with_and_without_prefix(self):
         self.app.app.registry.public_settings.add('myapp.paginate_by')
@@ -53,8 +54,8 @@ class HelloViewTest(BaseWebTest, unittest.TestCase):
         response = self.app.get('/')
         settings = response.json['settings']
         self.assertIn('cliquet.paginate_by', settings)
-        self.assertIn('myapp.paginate_by', settings)
-        self.assertIn('myapp.project_version', settings)
+        self.assertIn('paginate_by', settings)
+        self.assertIn('project_version', settings)
 
     def test_if_user_not_authenticated_no_userid_provided(self):
         response = self.app.get('/')

--- a/cliquet/tests/test_views_hello.py
+++ b/cliquet/tests/test_views_hello.py
@@ -37,8 +37,7 @@ class HelloViewTest(BaseWebTest, unittest.TestCase):
     def test_public_settings_are_shown_in_view(self):
         response = self.app.get('/')
         settings = response.json['settings']
-        expected = {'cliquet.batch_max_requests': 25,
-                    'batch_max_requests': 25}
+        expected = {'batch_max_requests': 25}
         self.assertEqual(expected, settings)
 
     def test_public_settings_can_be_set_from_registry(self):

--- a/cliquet/tests/test_views_hello.py
+++ b/cliquet/tests/test_views_hello.py
@@ -44,7 +44,7 @@ class HelloViewTest(BaseWebTest, unittest.TestCase):
         self.app.app.registry.public_settings.add('myapp.paginate_by')
         response = self.app.get('/')
         settings = response.json['settings']
-        self.assertIn('paginate_by', settings)
+        self.assertIn('myapp.paginate_by', settings)
 
     def test_public_settings_can_be_set_with_and_without_prefix(self):
         self.app.app.registry.public_settings.add('myapp.paginate_by')
@@ -53,7 +53,7 @@ class HelloViewTest(BaseWebTest, unittest.TestCase):
         response = self.app.get('/')
         settings = response.json['settings']
         self.assertIn('cliquet.paginate_by', settings)
-        self.assertIn('paginate_by', settings)
+        self.assertIn('myapp.paginate_by', settings)
         self.assertIn('project_version', settings)
 
     def test_if_user_not_authenticated_no_userid_provided(self):

--- a/cliquet/views/hello.py
+++ b/cliquet/views/hello.py
@@ -37,11 +37,14 @@ def get_hello(request):
     # specified with cliquet. (for retrocompability of clients for example).
     for setting in list(public_settings):
         if setting.startswith('cliquet.'):
-            value = settings[setting.replace('cliquet.', '', 1)]
+            unprefixed = setting.replace('cliquet.', '', 1)
+            value = settings[unprefixed]
+            # For retropatibility compat expose both for a while.
+            data['settings'][setting] = value
+            data['settings'][unprefixed] = value
         else:
             setting = setting.replace(project_name + '.', '')
             value = settings[setting]
-            setting = project_name + '.' + setting
         data['settings'][setting] = value
 
     prefixed_userid = getattr(request, 'prefixed_userid', None)

--- a/cliquet/views/hello.py
+++ b/cliquet/views/hello.py
@@ -39,11 +39,10 @@ def get_hello(request):
         if setting.startswith('cliquet.'):
             unprefixed = setting.replace('cliquet.', '', 1)
             value = settings[unprefixed]
-            # For retropatibility compat expose both for a while.
-            data['settings'][setting] = value
-            data['settings'][unprefixed] = value
+        elif setting.startswith(project_name + '.'):
+            unprefixed = setting.replace(project_name + '.', '')
+            value = settings[unprefixed]
         else:
-            setting = setting.replace(project_name + '.', '')
             value = settings[setting]
         data['settings'][setting] = value
 

--- a/cliquet_docs/api/utilities.rst
+++ b/cliquet_docs/api/utilities.rst
@@ -15,7 +15,7 @@ The returned value is a JSON mapping containing:
 - ``eos``: date of end of support in ISO 8601 format (``"yyyy-mm-dd"``, undefined if unknown)
 - ``documentation``: The URL to the service documentation. (this document!)
 - ``settings``: a mapping with the values of relevant public settings for clients
-    - ``cliquet.batch_max_requests``: Number of requests that can be made in a batch request.
+    - ``batch_max_requests``: Number of requests that can be made in a batch request.
 - ``userid``: The connected perso user id. The field is not present
   when no Authorization header is provided.
 


### PR DESCRIPTION
Refs https://github.com/mozilla-services/syncto/issues/48

r? @leplatrem @n1k0 