### PR TITLE
tweak tox options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ tests-once: install-dev
 	$(VENV)/bin/nosetests -s --with-mocha-reporter --with-coverage --cover-min-percentage=100 --cover-package=cliquet
 
 tests:
-	tox
+	$(VENV)/bin/tox
 
 clean:
 	find . -name '*.pyc' -delete

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist = py27,py34,pypy,py27-raw,flake8
+skip_missing_interpreters = True
 
 [testenv]
 commands =


### PR DESCRIPTION
we want to skip missing interpreters like pypy and point tox from within venv