### PR TITLE
Create the heartbeat if not present in the registry.

### DIFF
--- a/cliquet/__init__.py
+++ b/cliquet/__init__.py
@@ -95,7 +95,8 @@ def includeme(config):
     settings = config.get_settings()
 
     # Heartbeat registry.
-    config.registry.heartbeats = {}
+    if not hasattr(config.registry, 'heartbeats'):
+        config.registry.heartbeats = {}
 
     # Public settings registry.
     config.registry.public_settings = {'batch_max_requests'}

--- a/cliquet/tests/test_initialization.py
+++ b/cliquet/tests/test_initialization.py
@@ -88,6 +88,12 @@ class InitializationTest(unittest.TestCase):
         self.assertFalse(hasattr(config.registry, 'cache'))
         self.assertFalse(hasattr(config.registry, 'permission'))
 
+    def test_heartbeats_are_not_overwritten(self):
+        config = Configurator(settings=cliquet.DEFAULT_SETTINGS)
+        config.registry.heartbeats = {'oauth': lambda r: False}
+        cliquet.initialize(config, '0.0.1', 'project_name')
+        self.assertIn('oauth', config.registry.heartbeats)
+
     def test_environment_values_override_configuration(self):
         import os
 


### PR DESCRIPTION
This would let plugin create it if loaded before.