### PR TITLE
Rename resource collection attribute to model

### DIFF
--- a/cliquet/authorization.py
+++ b/cliquet/authorization.py
@@ -114,7 +114,7 @@ class RouteFactory(object):
                 # eventual NotFound.
                 resource = service.resource(request=request, context=self)
                 try:
-                    record = resource.collection.get_record(resource.record_id)
+                    record = resource.model.get_record(resource.record_id)
                     self.current_record = record
                 except storage_exceptions.RecordNotFoundError:
                     self.permission_object_id = service.collection_path.format(

--- a/cliquet/tests/resource/__init__.py
+++ b/cliquet/tests/resource/__init__.py
@@ -13,7 +13,7 @@ class BaseTest(unittest.TestCase):
         self.storage = memory.Memory()
         self.resource = self.resource_class(request=self.get_request(),
                                             context=self.get_context())
-        self.collection = self.resource.collection
+        self.model = self.resource.model
         self.patch_known_field = mock.patch.object(self.resource,
                                                    'is_known_field')
 
@@ -64,4 +64,4 @@ class ParentIdOverrideResourceTest(BaseTest):
 
         parent_id = self.resource.get_parent_id(request)
         self.assertEquals(parent_id, 'overrided')
-        self.assertEquals(self.resource.collection.parent_id, 'overrided')
+        self.assertEquals(self.resource.model.parent_id, 'overrided')

--- a/cliquet/tests/resource/test_cache_expires.py
+++ b/cliquet/tests/resource/test_cache_expires.py
@@ -22,7 +22,7 @@ class CacheExpires(BaseTest):
         self.last_response.cache_expires.assert_called_with(seconds=3)
 
     def test_cache_expires_is_also_on_record_get(self):
-        stored = self.collection.create_record({})
+        stored = self.model.create_record({})
         self.resource.record_id = stored['id']
         settings = self.resource.request.registry.settings
         settings[self.setting] = 3

--- a/cliquet/tests/resource/test_filter.py
+++ b/cliquet/tests/resource/test_filter.py
@@ -14,12 +14,12 @@ class FilteringTest(BaseTest):
                 'status': i % 3,
                 'favorite': (i % 4 == 0)
             }
-            self.collection.create_record(record)
+            self.model.create_record(record)
 
     def test_list_can_be_filtered_on_deleted_with_since(self):
-        since = self.collection.timestamp()
-        r = self.collection.create_record({})
-        self.collection.delete_record(r)
+        since = self.model.timestamp()
+        r = self.model.create_record({})
+        self.model.delete_record(r)
         self.resource.request.GET = {'_since': '%s' % since, 'deleted': 'true'}
         result = self.resource.collection_get()
         self.assertEqual(len(result['data']), 1)
@@ -27,20 +27,20 @@ class FilteringTest(BaseTest):
 
     def test_filter_on_id_is_supported(self):
         self.patch_known_field.stop()
-        r = self.collection.create_record({})
+        r = self.model.create_record({})
         self.resource.request.GET = {'id': '%s' % r['id']}
         result = self.resource.collection_get()
         self.assertEqual(result['data'][0], r)
 
     def test_list_cannot_be_filtered_on_deleted_without_since(self):
-        r = self.collection.create_record({})
-        self.collection.delete_record(r)
+        r = self.model.create_record({})
+        self.model.delete_record(r)
         self.resource.request.GET = {'deleted': 'true'}
         result = self.resource.collection_get()
         self.assertEqual(len(result['data']), 0)
 
     def test_filter_works_with_empty_list(self):
-        self.resource.collection.parent_id = 'alice'
+        self.resource.model.parent_id = 'alice'
         self.resource.request.GET = {'status': '1'}
         result = self.resource.collection_get()
         self.assertEqual(len(result['data']), 0)

--- a/cliquet/tests/resource/test_model.py
+++ b/cliquet/tests/resource/test_model.py
@@ -6,7 +6,7 @@ from cliquet.tests.resource import BaseTest
 class ModelTest(BaseTest):
     def setUp(self):
         super(ModelTest, self).setUp()
-        self.record = self.collection.create_record({'field': 'value'})
+        self.record = self.model.create_record({'field': 'value'})
 
     def test_list_gives_number_of_results_in_headers(self):
         self.resource.collection_get()
@@ -29,12 +29,12 @@ class CreateTest(BaseTest):
     def test_new_records_are_linked_to_owner(self):
         resp = self.resource.collection_post()['data']
         record_id = resp['id']
-        self.collection.get_record(record_id)  # not raising
+        self.model.get_record(record_id)  # not raising
 
     def test_create_record_returns_at_least_id_and_last_modified(self):
         record = self.resource.collection_post()['data']
-        self.assertIn(self.resource.collection.id_field, record)
-        self.assertIn(self.resource.collection.modified_field, record)
+        self.assertIn(self.resource.model.id_field, record)
+        self.assertIn(self.resource.model.modified_field, record)
         self.assertIn('field', record)
 
 
@@ -42,8 +42,8 @@ class DeleteModelTest(BaseTest):
     def setUp(self):
         super(DeleteModelTest, self).setUp()
         self.patch_known_field.start()
-        self.collection.create_record({'field': 'a'})
-        self.collection.create_record({'field': 'b'})
+        self.model.create_record({'field': 'a'})
+        self.model.create_record({'field': 'b'})
 
     def test_delete_on_list_removes_all_records(self):
         self.resource.collection_delete()
@@ -68,7 +68,7 @@ class DeleteModelTest(BaseTest):
 class IsolatedModelsTest(BaseTest):
     def setUp(self):
         super(IsolatedModelsTest, self).setUp()
-        self.stored = self.collection.create_record({}, parent_id='bob')
+        self.stored = self.model.create_record({}, parent_id='bob')
         self.resource.record_id = self.stored['id']
 
     def get_request(self):
@@ -89,8 +89,8 @@ class IsolatedModelsTest(BaseTest):
     def test_update_record_of_another_user_will_create_it(self):
         self.resource.request.validated = {'data': {'some': 'record'}}
         self.resource.put()
-        self.collection.get_record(record_id=self.stored['id'],
-                                   parent_id='basicauth:alice')  # not raising
+        self.model.get_record(record_id=self.stored['id'],
+                              parent_id='basicauth:alice')  # not raising
 
     def test_cannot_modify_record_of_other_user(self):
         self.assertRaises(httpexceptions.HTTPNotFound, self.resource.patch)

--- a/cliquet/tests/resource/test_object_permissions.py
+++ b/cliquet/tests/resource/test_object_permissions.py
@@ -36,7 +36,7 @@ class CollectionPermissionTest(PermissionTest):
 class ObtainRecordPermissionTest(PermissionTest):
     def setUp(self):
         super(ObtainRecordPermissionTest, self).setUp()
-        record = self.resource.collection.create_record({})
+        record = self.resource.model.create_record({})
         record_id = record['id']
         record_uri = '/articles/%s' % record_id
         self.permission.add_principal_to_ace(record_uri, 'read', 'fxa:user')
@@ -71,13 +71,13 @@ class ObtainRecordPermissionTest(PermissionTest):
 class SpecifyRecordPermissionTest(PermissionTest):
     def setUp(self):
         super(SpecifyRecordPermissionTest, self).setUp()
-        self.record = self.resource.collection.create_record({})
+        self.record = self.resource.model.create_record({})
         record_id = self.record['id']
         self.record_uri = '/articles/%s' % record_id
         self.permission.add_principal_to_ace(self.record_uri,
                                              'read',
                                              'fxa:user')
-        self.resource.collection.current_principal = 'basicauth:userid'
+        self.resource.model.current_principal = 'basicauth:userid'
         self.resource.record_id = record_id
         self.resource.request.validated = {'data': {}}
         self.resource.request.path = self.record_uri
@@ -163,7 +163,7 @@ class SpecifyRecordPermissionTest(PermissionTest):
 class DeletedRecordPermissionTest(PermissionTest):
     def setUp(self):
         super(DeletedRecordPermissionTest, self).setUp()
-        record = self.resource.collection.create_record({})
+        record = self.resource.model.create_record({})
         self.resource.record_id = record_id = record['id']
         self.record_uri = '/articles/%s' % record_id
         self.resource.request.route_path.return_value = self.record_uri
@@ -189,9 +189,9 @@ class DeletedRecordPermissionTest(PermissionTest):
 class GuestCollectionListTest(PermissionTest):
     def setUp(self):
         super(GuestCollectionListTest, self).setUp()
-        record1 = self.resource.collection.create_record({'letter': 'a'})
-        record2 = self.resource.collection.create_record({'letter': 'b'})
-        record3 = self.resource.collection.create_record({'letter': 'c'})
+        record1 = self.resource.model.create_record({'letter': 'a'})
+        record2 = self.resource.model.create_record({'letter': 'b'})
+        record3 = self.resource.model.create_record({'letter': 'c'})
 
         uri1 = '/articles/%s' % record1['id']
         uri2 = '/articles/%s' % record2['id']
@@ -231,10 +231,10 @@ class GuestCollectionListTest(PermissionTest):
 class GuestCollectionDeleteTest(PermissionTest):
     def setUp(self):
         super(GuestCollectionDeleteTest, self).setUp()
-        record1 = self.resource.collection.create_record({'letter': 'a'})
-        record2 = self.resource.collection.create_record({'letter': 'b'})
-        record3 = self.resource.collection.create_record({'letter': 'c'})
-        record4 = self.resource.collection.create_record({'letter': 'd'})
+        record1 = self.resource.model.create_record({'letter': 'a'})
+        record2 = self.resource.model.create_record({'letter': 'b'})
+        record3 = self.resource.model.create_record({'letter': 'c'})
+        record4 = self.resource.model.create_record({'letter': 'd'})
 
         uri1 = '/articles/%s' % record1['id']
         uri2 = '/articles/%s' % record2['id']
@@ -264,12 +264,12 @@ class GuestCollectionDeleteTest(PermissionTest):
         with mock.patch.object(self.resource, 'is_known_field'):
             result = self.resource.collection_delete()
         self.assertEqual(len(result['data']), 1)
-        records, _ = self.resource.collection.get_records()
+        records, _ = self.resource.model.get_records()
         self.assertEqual(len(records), 3)
 
     def test_guest_cannot_delete_records_if_not_allowed(self):
         self.resource.context.shared_ids = ['tata lili']
         result = self.resource.collection_delete()
         self.assertEqual(len(result['data']), 0)
-        records, _ = self.resource.collection.get_records()
+        records, _ = self.resource.model.get_records()
         self.assertEqual(len(records), 4)

--- a/cliquet/tests/resource/test_pagination.py
+++ b/cliquet/tests/resource/test_pagination.py
@@ -22,7 +22,7 @@ class PaginationTest(BaseTest):
                 'status': i % 4,
                 'unread': (i % 2 == 0)
             }
-            self.collection.create_record(record)
+            self.model.create_record(record)
 
     def _setup_next_page(self):
         next_page = self.last_response.headers['Next-Page']

--- a/cliquet/tests/resource/test_preconditions.py
+++ b/cliquet/tests/resource/test_preconditions.py
@@ -8,7 +8,7 @@ from cliquet.tests.resource import BaseTest
 class NotModifiedTest(BaseTest):
     def setUp(self):
         super(NotModifiedTest, self).setUp()
-        self.stored = self.collection.create_record({})
+        self.stored = self.model.create_record({})
 
         self.resource = BaseResource(request=self.get_request(),
                                      context=self.get_context())
@@ -67,7 +67,7 @@ class NotModifiedTest(BaseTest):
 class ModifiedMeanwhileTest(BaseTest):
     def setUp(self):
         super(ModifiedMeanwhileTest, self).setUp()
-        self.stored = self.collection.create_record({})
+        self.stored = self.model.create_record({})
 
         self.resource.collection_get()
         current = self.last_response.headers['ETag'][1:-1]
@@ -135,7 +135,7 @@ class ModifiedMeanwhileTest(BaseTest):
 
     def test_put_returns_412_if_changed_meanwhile(self):
         self.resource.record_id = self.stored['id']
-        self.collection.delete_record(self.stored)
+        self.model.delete_record(self.stored)
         self.assertRaises(httpexceptions.HTTPPreconditionFailed,
                           self.resource.put)
 
@@ -167,7 +167,7 @@ class ModifiedMeanwhileTest(BaseTest):
         self.assertRaises(httpexceptions.HTTPPreconditionFailed,
                           self.resource.put)
         self.resource.request.validated = {'data': {'field': 'new'}}
-        self.resource.record_id = self.resource.collection.id_generator()
+        self.resource.record_id = self.resource.model.id_generator()
         self.resource.put()  # not raising.
 
     def test_patch_returns_412_if_changed_meanwhile(self):

--- a/cliquet/tests/resource/test_sort.py
+++ b/cliquet/tests/resource/test_sort.py
@@ -20,10 +20,10 @@ class SortingTest(BaseTest):
                 'status': i % 4,
                 'unread': (i % 2 == 0)
             }
-            self.collection.create_record(record)
+            self.model.create_record(record)
 
     def test_sort_works_with_empty_list(self):
-        self.resource.collection.parent_id = 'alice'
+        self.resource.model.parent_id = 'alice'
         self.resource.request.GET = {'_sort': 'unread'}
         result = self.resource.collection_get()
         self.assertEqual(len(result['data']), 0)
@@ -54,7 +54,7 @@ class SortingTest(BaseTest):
         self.patch_known_field.stop()
         self.resource.request.GET = {'_sort': '-last_modified'}
         result = self.resource.collection_get()
-        tstamp = self.collection.timestamp()
+        tstamp = self.model.timestamp()
         self.assertEqual(result['data'][0]['last_modified'], tstamp)
 
     def test_single_basic_sort_by_attribute(self):

--- a/cliquet/tests/resource/test_sync.py
+++ b/cliquet/tests/resource/test_sync.py
@@ -18,7 +18,7 @@ class SinceModifiedTest(ThreadMixin, BaseTest):
 
         self.resource.request.validated = {'data': {}}
 
-        with mock.patch.object(self.collection.storage,
+        with mock.patch.object(self.model.storage,
                                '_bump_timestamp') as msec_mocked:
             for i in range(6):
                 msec_mocked.return_value = i
@@ -109,7 +109,7 @@ class SinceModifiedTest(ThreadMixin, BaseTest):
         self.assertEqual(len(result['data']), 0)
 
     def test_filter_works_with_empty_list(self):
-        self.resource.collection.parent_id = 'alice'
+        self.resource.model.parent_id = 'alice'
         self.resource.request.GET = {'_since': '3'}
         result = self.resource.collection_get()
         self.assertEqual(len(result['data']), 0)
@@ -148,7 +148,7 @@ class SinceModifiedTest(ThreadMixin, BaseTest):
                 time.sleep(.100)  # 100 msec
                 return [], 0
 
-            with mock.patch.object(self.collection.storage,
+            with mock.patch.object(self.model.storage,
                                    'get_all', delayed_get):
                 self.resource.collection_get()
                 fetch_at = self.last_response.headers['ETag'][1:-1]

--- a/cliquet/tests/test_authorization.py
+++ b/cliquet/tests/test_authorization.py
@@ -22,10 +22,10 @@ class RouteFactoryTest(unittest.TestCase):
             resource = mock.MagicMock()
             resource.record_id = 1
             if record_not_found:
-                resource.collection.get_record.side_effect = \
+                resource.model.get_record.side_effect = \
                     storage_exceptions.RecordNotFoundError
             else:
-                resource.collection.get_record.return_value = 1
+                resource.model.get_record.return_value = 1
             current_service().resource.return_value = resource
 
             # Do the actual call.
@@ -52,7 +52,7 @@ class RouteFactoryTest(unittest.TestCase):
             # Patch current service.
             resource = mock.MagicMock()
             resource.record_id = 1
-            resource.collection.get_record.side_effect = \
+            resource.model.get_record.side_effect = \
                 storage_exceptions.RecordNotFoundError
             current_service().resource.return_value = resource
             current_service().collection_path = '/buckets/{bucket_id}'
@@ -72,7 +72,7 @@ class RouteFactoryTest(unittest.TestCase):
             # Patch current service.
             resource = mock.MagicMock()
             resource.record_id = 1
-            resource.collection.get_record.return_value = mock.sentinel.record
+            resource.model.get_record.return_value = mock.sentinel.record
             current_service().resource.return_value = resource
             # Do the actual call.
             request = DummyRequest(method='put')

--- a/cliquet_docs/ecosystem.rst
+++ b/cliquet_docs/ecosystem.rst
@@ -261,9 +261,9 @@ Indexed resource in :file:`cliquet_indexing/resource.py`:
 
 .. code-block:: python
 
-    class IndexedCollection(cliquet.resource.Collection):
+    class IndexedModel(cliquet.resource.Model):
         def create_record(self, record):
-            r = super(IndexedCollection, self).create_record(self, record)
+            r = super(IndexedModel, self).create_record(self, record)
 
             self.indexer.index_record(self, record)
 
@@ -272,7 +272,7 @@ Indexed resource in :file:`cliquet_indexing/resource.py`:
     class IndexedResource(cliquet.resource.BaseResource):
         def __init__(self, request):
             super(IndexedResource, self).__init__(request)
-            self.collection.indexer = request.registry.indexer
+            self.model.indexer = request.registry.indexer
 
 .. note::
 

--- a/cliquet_docs/reference/resource.rst
+++ b/cliquet_docs/reference/resource.rst
@@ -130,7 +130,7 @@ or at the resource level:
     class Mushroom(resource.BaseResource):
         def __init__(request):
             super(Mushroom, self).__init__(request)
-            self.collection.id_generator = MsecId()
+            self.model.id_generator = MsecId()
 
 
 Generators objects


### PR DESCRIPTION
Follow-up of #490 

This way there will be no confusion. The term «collection» will be only used for one thing : the list of records for a resource. 

@Natim r?