### PR TITLE
Add cliquet.includes setting

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,8 @@ This document describes changes between each past release.
 **New features**
 
 - Added notifications (#488)
+- Added ``cliquet.includes`` setting allowing loading of plugins once Cliquet
+  is initialized (unlike ``pyramid.includes``).
 
 **Protocol**
 

--- a/cliquet/__init__.py
+++ b/cliquet/__init__.py
@@ -38,6 +38,7 @@ DEFAULT_SETTINGS = {
     'http_host': None,
     'http_scheme': None,
     'id_generator': 'cliquet.storage.generators.UUID4',
+    'includes': '',
     'initialization_sequence': (
         'cliquet.initialization.setup_request_bound_data',
         'cliquet.initialization.setup_json_serializer',
@@ -97,11 +98,18 @@ def includeme(config):
     settings = config.get_settings()
 
     # Heartbeat registry.
-    if not hasattr(config.registry, 'heartbeats'):
-        config.registry.heartbeats = {}
+    config.registry.heartbeats = {}
 
     # Public settings registry.
     config.registry.public_settings = {'batch_max_requests'}
+
+    # Setup cornice.
+    config.include("cornice")
+
+    # Include cliquet plugins after init, unlike pyramid includes.
+    includes = aslist(settings['includes'])
+    for app in includes:
+        config.include(app)
 
     # Setup components.
     for step in aslist(settings['initialization_sequence']):
@@ -121,9 +129,6 @@ def includeme(config):
     Service.cors_max_age = int(cors_max_age) if cors_max_age else None
 
     Service.error_handler = lambda self, e: errors.json_error_handler(e)
-
-    # Setup cornice.
-    config.include("cornice")
 
     # Scan views.
     config.scan("cliquet.views")

--- a/cliquet/tests/test_initialization.py
+++ b/cliquet/tests/test_initialization.py
@@ -88,11 +88,17 @@ class InitializationTest(unittest.TestCase):
         self.assertFalse(hasattr(config.registry, 'cache'))
         self.assertFalse(hasattr(config.registry, 'permission'))
 
-    def test_heartbeats_are_not_overwritten(self):
+    def test_cliquet_includes_are_included_manually(self):
         config = Configurator(settings=cliquet.DEFAULT_SETTINGS)
-        config.registry.heartbeats = {'oauth': lambda r: False}
-        cliquet.initialize(config, '0.0.1', 'project_name')
-        self.assertIn('oauth', config.registry.heartbeats)
+        config.add_settings({'includes': 'elastic history'})
+        config.route_prefix = 'v2'
+
+        with mock.patch.object(config, 'include'):
+            with mock.patch.object(config, 'scan'):
+                cliquet.includeme(config)
+
+                config.include.assert_any_call('elastic')
+                config.include.assert_any_call('history')
 
     def test_environment_values_override_configuration(self):
         import os

--- a/cliquet_docs/ecosystem.rst
+++ b/cliquet_docs/ecosystem.rst
@@ -67,7 +67,7 @@ Alternatively, packages can also be included via configuration:
 .. code-block:: ini
 
     # myproject.ini
-    pyramid.includes = cliquet_elasticsearch
+    cliquet.includes = cliquet_elasticsearch
                        pyramid_debugtoolbar
 
 


### PR DESCRIPTION
With `pyramid.includes` the plugins are loaded before the main application.

As a consequence, when a cliquet plugin is loaded, some Cliquet setup is not ready yet.

So far, we handled this with safety and double-initialization. But it had some drawbacks:

- the URL prefix mecanism was not setup yet, thus preventing plugins registering their URLs with or without prefixes
- the settings prefixes were not handled yet, preventing plugins to rely on general settings properly (e.g. `cliquet.cache_backend` vs. `kinto.cache_backend`)
etc.
- common libraries like cornice had to be included twice (in plugin to scan views and in cliquet in case no plugin was used)


This PR add a simple include mecanism, just as `pyramid.includes`, that will include plugin once basic cliquet stuff is initialized.

It does not prevent `pyramid.includes` to be used, but when a cliquet plugin relies on cliquet objects or mecanism, it shall be included with `cliquet.includes` (or `kinto.includes`)

@Natim r?