### PR TITLE
One transaction per request

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,8 +9,17 @@ This document describes changes between each past release.
 
 **Protocol**
 
-* ``_since`` and ``_before`` now accepts an integer value between quotes ``"``,
+- ``_since`` and ``_before`` now accepts an integer value between quotes ``"``,
   as it would be returned in the ``ETag`` response header.
+- A batch request now fails if one of the subrequests fails (#510)
+  (*see new feature about transactions*)
+
+**New features**
+
+- A transaction now covers the whole request/response cycle (#510, Kinto/kinto#194).
+  If an error occurs during the request processing, every operation performed
+  is rolled back. **Note:** This is only enabled with *PostgreSQL* backends. In
+  other words, the rollback has no effect on backends like *Redis* or *Memory*.
 
 - Add the ``protocol_version`` to tell which protocol version is
   implemented by the service. (#324)
@@ -34,6 +43,7 @@ This document describes changes between each past release.
 - Switch to SQLAlchemy for smarter connections pools.
 - Added a simple end-to-end test on a *Cliquet* sample application, using
   `Loads <http://github.com/loads/>`_ (fixes #512)
+- Switched to SQLAlchemy sessions instead of raw connections and cursors (#510)
 
 
 2.10.2 (2015-11-10)

--- a/cliquet/__init__.py
+++ b/cliquet/__init__.py
@@ -79,6 +79,7 @@ DEFAULT_SETTINGS = {
     'storage_url': '',
     'storage_max_fetch_size': 10000,
     'storage_pool_size': 25,
+    'transaction_per_request': True,
     'userid_hmac_secret': '',
     'version_prefix_redirect_enabled': True,
     'trailing_slash_redirect_enabled': True,
@@ -109,6 +110,9 @@ def includeme(config):
 
     # Setup cornice.
     config.include("cornice")
+
+    # Per-request transaction.
+    config.include("pyramid_tm")
 
     # Include cliquet plugins after init, unlike pyramid includes.
     includes = aslist(settings['includes'])

--- a/cliquet/cache/postgresql/__init__.py
+++ b/cliquet/cache/postgresql/__init__.py
@@ -78,30 +78,30 @@ class Cache(CacheBase):
         query = """
         SELECT EXTRACT(SECOND FROM (ttl - now())) AS ttl
           FROM cache
-         WHERE key = %s
+         WHERE key = :key
            AND ttl IS NOT NULL;
         """
         with self.client.connect() as conn:
-            result = conn.execute(query, (key,))
+            result = conn.execute(query, dict(key=key))
             if result.rowcount > 0:
                 return result.fetchone()['ttl']
         return -1
 
     def expire(self, key, ttl):
         query = """
-        UPDATE cache SET ttl = sec2ttl(%s) WHERE key = %s;
+        UPDATE cache SET ttl = sec2ttl(:ttl) WHERE key = :key;
         """
         with self.client.connect() as conn:
-            conn.execute(query, (ttl, key,))
+            conn.execute(query, dict(ttl=ttl, key=key))
 
     def set(self, key, value, ttl=None):
         query = """
         WITH upsert AS (
-            UPDATE cache SET value = %(value)s, ttl = sec2ttl(%(ttl)s)
-             WHERE key=%(key)s
+            UPDATE cache SET value = :value, ttl = sec2ttl(:ttl)
+             WHERE key=:key
             RETURNING *)
         INSERT INTO cache (key, value, ttl)
-        SELECT %(key)s, %(value)s, sec2ttl(%(ttl)s)
+        SELECT :key, :value, sec2ttl(:ttl)
         WHERE NOT EXISTS (SELECT * FROM upsert)
         """
         value = json.dumps(value)
@@ -110,18 +110,18 @@ class Cache(CacheBase):
 
     def get(self, key):
         purge = "DELETE FROM cache WHERE ttl IS NOT NULL AND now() > ttl;"
-        query = "SELECT value FROM cache WHERE key = %s;"
+        query = "SELECT value FROM cache WHERE key = :key;"
         with self.client.connect() as conn:
             conn.execute(purge)
-            result = conn.execute(query, (key,))
+            result = conn.execute(query, dict(key=key))
             if result.rowcount > 0:
                 value = result.fetchone()['value']
                 return json.loads(value)
 
     def delete(self, key):
-        query = "DELETE FROM cache WHERE key = %s"
+        query = "DELETE FROM cache WHERE key = :key"
         with self.client.connect() as conn:
-            conn.execute(query, (key,))
+            conn.execute(query, dict(key=key))
 
 
 def load_from_config(config):

--- a/cliquet/cache/postgresql/__init__.py
+++ b/cliquet/cache/postgresql/__init__.py
@@ -62,7 +62,8 @@ class Cache(CacheBase):
         # Create schema
         here = os.path.abspath(os.path.dirname(__file__))
         schema = open(os.path.join(here, 'schema.sql')).read()
-        with self.client.connect() as conn:
+        # Since called outside request, force commit.
+        with self.client.connect(force_commit=True) as conn:
             conn.execute(schema)
         logger.info('Created PostgreSQL cache tables')
 
@@ -70,7 +71,8 @@ class Cache(CacheBase):
         query = """
         DELETE FROM cache;
         """
-        with self.client.connect() as conn:
+        # Since called outside request (e.g. tests), force commit.
+        with self.client.connect(force_commit=True) as conn:
             conn.execute(query)
         logger.debug('Flushed PostgreSQL cache tables')
 

--- a/cliquet/permission/postgresql/__init__.py
+++ b/cliquet/permission/postgresql/__init__.py
@@ -63,7 +63,8 @@ class Permission(PermissionBase):
         # Create schema
         here = os.path.abspath(os.path.dirname(__file__))
         schema = open(os.path.join(here, 'schema.sql')).read()
-        with self.client.connect() as conn:
+        # Since called outside request, force commit.
+        with self.client.connect(force_commit=True) as conn:
             conn.execute(schema)
         logger.info('Created PostgreSQL permission tables')
 
@@ -72,7 +73,8 @@ class Permission(PermissionBase):
         DELETE FROM user_principals;
         DELETE FROM access_control_entries;
         """
-        with self.client.connect() as conn:
+        # Since called outside request (e.g. tests), force commit.
+        with self.client.connect(force_commit=True) as conn:
             conn.execute(query)
         logger.debug('Flushed PostgreSQL permission tables')
 

--- a/cliquet/storage/postgresql/__init__.py
+++ b/cliquet/storage/postgresql/__init__.py
@@ -70,7 +70,8 @@ class Storage(StorageBase):
     def _execute_sql_file(self, filepath):
         here = os.path.abspath(os.path.dirname(__file__))
         schema = open(os.path.join(here, filepath)).read()
-        with self.client.connect() as conn:
+        # Since called outside request, force commit.
+        with self.client.connect(force_commit=True) as conn:
             conn.execute(schema)
 
     def initialize_schema(self):
@@ -177,7 +178,7 @@ class Storage(StorageBase):
         DELETE FROM records;
         DELETE FROM metadata;
         """
-        with self.client.connect() as conn:
+        with self.client.connect(force_commit=True) as conn:
             conn.execute(query)
         logger.debug('Flushed PostgreSQL storage tables')
 

--- a/cliquet/storage/postgresql/__init__.py
+++ b/cliquet/storage/postgresql/__init__.py
@@ -60,7 +60,7 @@ class Storage(StorageBase):
 
     """
 
-    schema_version = 7
+    schema_version = 8
 
     def __init__(self, client, max_fetch_size, *args, **kwargs):
         super(Storage, self).__init__(*args, **kwargs)

--- a/cliquet/storage/postgresql/client.py
+++ b/cliquet/storage/postgresql/client.py
@@ -29,7 +29,7 @@ class PostgreSQLClient(object):
         A COMMIT is performed on the current transaction if everything went
         well. Otherwise transaction is ROLLBACK, and everything cleaned up.
         """
-        with_transaction = (not readonly and self.commit_manually)
+        with_transaction = not readonly and self.commit_manually
         session = None
         try:
             # Pull connection from pool.

--- a/cliquet/storage/postgresql/client.py
+++ b/cliquet/storage/postgresql/client.py
@@ -7,8 +7,9 @@ from cliquet.utils import sqlalchemy
 
 
 class PostgreSQLClient(object):
-    def __init__(self, engine):
-        self._engine = engine
+    def __init__(self, session_factory, commit_manually=True):
+        self.session_factory = session_factory
+        self.commit_manually = commit_manually
 
         # # Register ujson, globally for all futur cursors
         # with self.connect() as cursor:
@@ -18,40 +19,37 @@ class PostgreSQLClient(object):
 
     @contextlib.contextmanager
     def connect(self, readonly=False):
-        """Pulls a connection from the pool when context is entered and
+        """
+        Pulls a connection from the pool when context is entered and
         returns it when context is exited.
 
         A COMMIT is performed on the current transaction if everything went
         well. Otherwise transaction is ROLLBACK, and everything cleaned up.
-
-        XXX: Committing should not happen here but using a global transaction
-        manager like `pyramid-tm`.
         """
-        connection = None
-        trans = None
+        with_transaction = (not readonly and self.commit_manually)
+        session = None
         try:
-            # Pull from pool.
-            connection = self._engine.connect()
-            if not readonly:
-                trans = connection.begin()
+            # Pull connection from pool.
+            session = self.session_factory()
             # Start context
-            yield connection
+            yield session
             # Success
-            if not readonly:
-                trans.commit()
-            # Give back to pool.
-            connection.close()
+            if with_transaction:
+                session.commit()
+                # Give back to pool.
+                session.close()
 
         except sqlalchemy.exc.SQLAlchemyError as e:
             logger.error(e)
-            if trans:
-                trans.rollback()
-            if connection:
-                connection.close()
+            if session:
+                if with_transaction:
+                    session.rollback()
+                    session.close()
             raise exceptions.BackendError(original=e)
 
 
-_ENGINES = {}
+# Reuse existing client if same URL.
+_CLIENTS = {}
 
 
 def create_from_config(config, prefix=''):
@@ -62,25 +60,30 @@ def create_from_config(config, prefix=''):
                    "Refer to installation section in documentation.")
         raise ImportWarning(message)
 
-    settings = config.get_settings()
-    url = settings[prefix + 'url']
+    settings = config.get_settings().copy()
+    # Custom Cliquet settings, unsupported by SQLAlchemy.
+    settings.pop(prefix + 'backend', None)
+    settings.pop(prefix + 'max_fetch_size', None)
 
-    if url in _ENGINES:
+    url = settings[prefix + 'url']
+    existing_client = _CLIENTS.get(url)
+    if existing_client:
         msg = ("Reuse existing PostgreSQL connection. "
                "Parameters %s* will be ignored." % prefix)
         warnings.warn(msg)
-        return PostgreSQLClient(_ENGINES[url])
+        return existing_client
 
-    # Initialize SQLAlchemy engine.
+    # Initialize SQLAlchemy engine from settings.
     poolclass_key = prefix + 'poolclass'
     settings.setdefault(poolclass_key, 'sqlalchemy.pool.QueuePool')
     settings[poolclass_key] = config.maybe_dotted(settings[poolclass_key])
-    settings.pop(prefix + 'max_fetch_size', None)
-    settings.pop(prefix + 'backend', None)
-
     engine = sqlalchemy.engine_from_config(settings, prefix=prefix, url=url)
 
-    # Store one engine per URI.
-    _ENGINES[url] = engine
+    # Initialize thread-safe session factory.
+    from sqlalchemy.orm import sessionmaker, scoped_session
+    session_factory = scoped_session(sessionmaker(bind=engine))
 
-    return PostgreSQLClient(engine)
+    # Store one client per URI.
+    client = PostgreSQLClient(session_factory)
+    _CLIENTS[url] = client
+    return client

--- a/cliquet/storage/postgresql/migrations/migration_007_008.sql
+++ b/cliquet/storage/postgresql/migrations/migration_007_008.sql
@@ -1,0 +1,66 @@
+--
+-- Helper that returns the current collection timestamp.
+--
+CREATE OR REPLACE FUNCTION collection_timestamp(uid VARCHAR, resource VARCHAR)
+RETURNS TIMESTAMP AS $$
+DECLARE
+    ts_records TIMESTAMP;
+    ts_deleted TIMESTAMP;
+BEGIN
+    --
+    -- This is fast because an index was created for ``parent_id``,
+    -- ``collection_id``, and ``last_modified`` with descending sorting order.
+    --
+    SELECT last_modified INTO ts_records
+      FROM records
+     WHERE parent_id = uid
+       AND collection_id = resource
+     ORDER BY last_modified DESC LIMIT 1;
+
+    SELECT last_modified INTO ts_deleted
+      FROM deleted
+     WHERE parent_id = uid
+       AND collection_id = resource
+     ORDER BY last_modified DESC LIMIT 1;
+
+    -- Latest of records/deleted or current if empty
+    RETURN coalesce(greatest(ts_deleted, ts_records), clock_timestamp());
+END;
+$$ LANGUAGE plpgsql;
+
+--
+-- Triggers to set last_modified on INSERT/UPDATE
+--
+DROP TRIGGER IF EXISTS tgr_records_last_modified ON records;
+DROP TRIGGER IF EXISTS tgr_deleted_last_modified ON deleted;
+
+CREATE OR REPLACE FUNCTION bump_timestamp()
+RETURNS trigger AS $$
+DECLARE
+    previous TIMESTAMP;
+    current TIMESTAMP;
+BEGIN
+    --
+    -- This bumps the current timestamp to 1 msec in the future if the previous
+    -- timestamp is equal to the current one (or higher if was bumped already).
+    --
+    -- If a bunch of requests from the same user on the same collection
+    -- arrive in the same millisecond, the unicity constraint can raise
+    -- an error (operation is cancelled).
+    -- See https://github.com/mozilla-services/cliquet/issues/25
+    --
+    previous := collection_timestamp(NEW.parent_id, NEW.collection_id);
+    current := clock_timestamp();
+
+    IF previous >= current THEN
+        current := previous + INTERVAL '1 milliseconds';
+    END IF;
+
+    NEW.last_modified := current;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Bump storage schema version.
+INSERT INTO metadata (name, value) VALUES ('storage_schema_version', '8');

--- a/cliquet/storage/postgresql/schema.sql
+++ b/cliquet/storage/postgresql/schema.sql
@@ -146,7 +146,7 @@ BEGIN
      ORDER BY last_modified DESC LIMIT 1;
 
     -- Latest of records/deleted or current if empty
-    RETURN coalesce(greatest(ts_deleted, ts_records), localtimestamp);
+    RETURN coalesce(greatest(ts_deleted, ts_records), clock_timestamp());
 END;
 $$ LANGUAGE plpgsql;
 
@@ -172,7 +172,7 @@ BEGIN
     -- See https://github.com/mozilla-services/cliquet/issues/25
     --
     previous := collection_timestamp(NEW.parent_id, NEW.collection_id);
-    current := localtimestamp;
+    current := clock_timestamp();
 
     IF previous >= current THEN
         current := previous + INTERVAL '1 milliseconds';
@@ -204,4 +204,4 @@ INSERT INTO metadata (name, value) VALUES ('created_at', NOW()::TEXT);
 
 -- Set storage schema version.
 -- Should match ``cliquet.storage.postgresql.PostgreSQL.schema_version``
-INSERT INTO metadata (name, value) VALUES ('storage_schema_version', '7');
+INSERT INTO metadata (name, value) VALUES ('storage_schema_version', '8');

--- a/cliquet/tests/test_cache.py
+++ b/cliquet/tests/test_cache.py
@@ -191,6 +191,6 @@ class PostgreSQLCacheTest(BaseTestCache, unittest.TestCase):
     def setUp(self):
         super(PostgreSQLCacheTest, self).setUp()
         self.client_error_patcher = mock.patch.object(
-            self.cache.client._engine,
-            'connect',
+            self.cache.client,
+            'session_factory',
             side_effect=sqlalchemy.exc.SQLAlchemyError)

--- a/cliquet/tests/test_permission.py
+++ b/cliquet/tests/test_permission.py
@@ -464,6 +464,7 @@ class RedisPermissionTest(BaseTestPermission, unittest.TestCase):
 class PostgreSQLPermissionTest(BaseTestPermission, unittest.TestCase):
     backend = postgresql_backend
     settings = {
+        'permission_backend': 'cliquet.permission.postgresql',
         'permission_pool_size': 10,
         'permission_url': 'postgres://postgres:postgres@localhost:5432/testdb'
     }

--- a/cliquet/tests/test_permission.py
+++ b/cliquet/tests/test_permission.py
@@ -471,6 +471,6 @@ class PostgreSQLPermissionTest(BaseTestPermission, unittest.TestCase):
     def setUp(self):
         super(PostgreSQLPermissionTest, self).setUp()
         self.client_error_patcher = [mock.patch.object(
-            self.permission.client._engine,
-            'connect',
+            self.permission.client,
+            'session_factory',
             side_effect=sqlalchemy.exc.SQLAlchemyError)]

--- a/cliquet/tests/test_storage.py
+++ b/cliquet/tests/test_storage.py
@@ -1015,8 +1015,8 @@ class PostgresqlStorageTest(StorageTest, unittest.TestCase):
     def setUp(self):
         super(PostgresqlStorageTest, self).setUp()
         self.client_error_patcher = mock.patch.object(
-            self.storage.client._engine,
-            'connect',
+            self.storage.client,
+            'session_factory',
             side_effect=sqlalchemy.exc.SQLAlchemyError)
 
     def test_number_of_fetched_records_can_be_limited_in_settings(self):
@@ -1043,7 +1043,7 @@ class PostgresqlStorageTest(StorageTest, unittest.TestCase):
             with self.storage.client.connect() as conn:
                 query = "INSERT INTO metadata VALUES ('roll', 'back');"
                 conn.execute(query)
-                conn.connection.commit()
+                conn.commit()
 
                 query = "INSERT INTO metadata VALUES ('roll', 'rock');"
                 conn.execute(query)
@@ -1061,8 +1061,8 @@ class PostgresqlStorageTest(StorageTest, unittest.TestCase):
         config = self._get_config()
         storage1 = self.backend.load_from_config(config)
         storage2 = self.backend.load_from_config(config)
-        self.assertEqual(id(storage1.client._engine),
-                         id(storage2.client._engine))
+        self.assertEqual(id(storage1.client),
+                         id(storage2.client))
 
     def test_warns_if_configured_pool_size_differs_for_same_backend_type(self):
         self.backend.load_from_config(self._get_config())

--- a/cliquet/tests/test_storage.py
+++ b/cliquet/tests/test_storage.py
@@ -1003,7 +1003,7 @@ class RedisStorageTest(MemoryStorageTest, unittest.TestCase):
 
 
 @skip_if_no_postgresql
-class PostgresqlStorageTest(StorageTest, unittest.TestCase):
+class PostgreSQLStorageTest(StorageTest, unittest.TestCase):
     backend = postgresql
     settings = {
         'storage_max_fetch_size': 10000,
@@ -1013,7 +1013,7 @@ class PostgresqlStorageTest(StorageTest, unittest.TestCase):
     }
 
     def setUp(self):
-        super(PostgresqlStorageTest, self).setUp()
+        super(PostgreSQLStorageTest, self).setUp()
         self.client_error_patcher = mock.patch.object(
             self.storage.client,
             'session_factory',

--- a/cliquet/tests/test_storage_migrations.py
+++ b/cliquet/tests/test_storage_migrations.py
@@ -111,7 +111,7 @@ class PostgresqlStorageMigrationTest(unittest.TestCase):
             before = {'drink': 'cacao'}
             query = """
             INSERT INTO records (user_id, resource_name, data)
-            VALUES (%(user_id)s, %(resource_name)s, %(data)s::JSON)
+            VALUES (:user_id, :resource_name, (:data)::JSON)
             RETURNING id, as_epoch(last_modified) AS last_modified;
             """
             placeholders = dict(user_id='jean-louis',

--- a/cliquet/tests/test_storage_migrations.py
+++ b/cliquet/tests/test_storage_migrations.py
@@ -18,8 +18,8 @@ class PostgresqlStorageMigrationTest(unittest.TestCase):
         if sqlalchemy is None:
             return
 
-        from .test_storage import PostgresqlStorageTest
-        self.settings = PostgresqlStorageTest.settings.copy()
+        from .test_storage import PostgreSQLStorageTest
+        self.settings = PostgreSQLStorageTest.settings.copy()
         self.config = testing.setUp()
         self.config.add_settings(self.settings)
         self.version = postgresql.Storage.schema_version

--- a/cliquet/tests/test_views_batch.py
+++ b/cliquet/tests/test_views_batch.py
@@ -65,17 +65,14 @@ class BatchViewTest(BaseWebTest, unittest.TestCase):
         self.assertEqual(error['body']['code'], 404)
         self.assertIn('message', error['body'])
 
-    def test_internal_errors_are_returned_within_responses(self):
+    def test_internal_errors_makes_the_batch_fail(self):
         request = {'path': '/v0/'}
         body = {'requests': [request]}
 
         with mock.patch('cliquet.views.hello.get_eos') as mocked:
             mocked.side_effect = AttributeError
-            resp = self.app.post_json('/batch', body, headers=self.headers)
-
-        error = resp.json['responses'][0]
-        self.assertEqual(error['status'], 500)
-        self.assertEqual(error['body']['errno'], 999)
+            self.app.post_json('/batch', body, headers=self.headers,
+                               status=500)
 
     def test_batch_cannot_be_recursive(self):
         requests = {'requests': [{'path': '/v0/'}]}

--- a/cliquet/tests/test_views_transaction.py
+++ b/cliquet/tests/test_views_transaction.py
@@ -1,0 +1,112 @@
+import mock
+
+from cliquet.storage.exceptions import BackendError
+from cliquet.utils import sqlalchemy
+from .support import BaseWebTest, unittest, skip_if_no_postgresql
+
+
+class PostgreSQLTest(BaseWebTest):
+    def get_app_settings(self, extras=None):
+        settings = super(PostgreSQLTest, self).get_app_settings(extras)
+        if sqlalchemy is not None:
+            from .test_storage import PostgreSQLStorageTest
+            from .test_permission import PostgreSQLPermissionTest
+            settings.update(**PostgreSQLStorageTest.settings)
+            settings.update(**PostgreSQLPermissionTest.settings)
+            settings.pop('storage_poolclass', None)
+            settings.pop('permission_poolclass', None)
+        return settings
+
+    def run_failing_batch(self):
+        patch = mock.patch.object(
+            self.storage,
+            'delete_all',
+            side_effect=BackendError('boom'))
+        self.addCleanup(patch.stop)
+        patch.start()
+        request_create = {
+            'method': 'POST',
+            'path': '/mushrooms',
+            'body': {'data': {'name': 'Amanite'}}
+        }
+        request_delete = {
+            'method': 'DELETE',
+            'path': '/mushrooms'
+        }
+        body = {'requests': [request_create, request_create, request_delete]}
+        self.app.post_json('/batch', body, headers=self.headers, status=503)
+
+    def run_failing_post(self):
+        patch = mock.patch.object(
+            self.permission,
+            'add_principal_to_ace',
+            side_effect=BackendError('boom'))
+        self.addCleanup(patch.stop)
+        patch.start()
+        self.app.post_json('/psilos',
+                           {'data': {'name': 'Amanite'}},
+                           headers=self.headers,
+                           status=503)
+
+
+@skip_if_no_postgresql
+class TransactionTest(PostgreSQLTest, unittest.TestCase):
+
+    def test_storage_operations_are_committed_on_success(self):
+        request_create = {
+            'method': 'POST',
+            'path': '/mushrooms',
+            'body': {'data': {'name': 'Trompette de la mort'}}
+        }
+        body = {'requests': [request_create, request_create, request_create]}
+        self.app.post_json('/batch', body, headers=self.headers)
+        resp = self.app.get('/mushrooms', headers=self.headers)
+        self.assertEqual(len(resp.json['data']), 3)
+
+    def test_transaction_isolation_within_request(self):
+        request_create = {
+            'method': 'POST',
+            'path': '/mushrooms',
+            'body': {'data': {'name': 'Vesse de loup'}}
+        }
+        request_get = {
+            'method': 'GET',
+            'path': '/mushrooms',
+        }
+        body = {'requests': [request_create, request_get]}
+        resp = self.app.post_json('/batch', body, headers=self.headers)
+        self.assertEqual(resp.json['responses'][1]['body']['data'][0]['name'],
+                         'Vesse de loup')
+
+    def test_modifications_are_rolled_back_on_error(self):
+        self.run_failing_batch()
+
+        resp = self.app.get('/mushrooms', headers=self.headers)
+        self.assertEqual(len(resp.json['data']), 0)
+
+    def test_modifications_are_rolled_back_on_error_accross_backends(self):
+        self.run_failing_post()
+
+        resp = self.app.get('/psilos', headers=self.headers)
+        self.assertEqual(len(resp.json['data']), 0)
+
+
+@skip_if_no_postgresql
+class WithoutTransactionTest(PostgreSQLTest, unittest.TestCase):
+
+    def get_app_settings(self, extras=None):
+        settings = super(WithoutTransactionTest, self).get_app_settings(extras)
+        settings['transaction_per_request'] = False
+        return settings
+
+    def test_modifications_are_not_rolled_back_on_error(self):
+        self.run_failing_batch()
+
+        resp = self.app.get('/mushrooms', headers=self.headers)
+        self.assertEqual(len(resp.json['data']), 2)
+
+    def test_modifications_are_not_rolled_back_on_error_accross_backends(self):
+        self.run_failing_post()
+
+        resp = self.app.get('/psilos', headers=self.headers)
+        self.assertEqual(len(resp.json['data']), 1)

--- a/cliquet/utils.py
+++ b/cliquet/utils.py
@@ -260,7 +260,7 @@ def build_response(response, request):
     return dict_obj
 
 
-def follow_subrequest(request, subrequest):
+def follow_subrequest(request, subrequest, **kwargs):
     """Run a subrequest (e.g. batch), and follow the redirection if any.
 
     :rtype: tuple
@@ -268,7 +268,7 @@ def follow_subrequest(request, subrequest):
               if no redirection happened.)
     """
     try:
-        return request.invoke_subrequest(subrequest), subrequest
+        return request.invoke_subrequest(subrequest, **kwargs), subrequest
     except httpexceptions.HTTPRedirection as e:
         new_location = e.headers['Location']
         new_request = Request.blank(path=new_location,
@@ -277,7 +277,7 @@ def follow_subrequest(request, subrequest):
                                     method=subrequest.method)
         new_request.bound_data = subrequest.bound_data
         new_request.parent = getattr(subrequest, 'parent', None)
-        return request.invoke_subrequest(new_request), new_request
+        return request.invoke_subrequest(new_request, **kwargs), new_request
 
 
 def encode_header(value, encoding='utf-8'):

--- a/cliquet/views/batch.py
+++ b/cliquet/views/batch.py
@@ -95,7 +95,6 @@ def post_batch(request):
 
         sublogger.bind(path=subrequest.path,
                        method=subrequest.method)
-
         try:
             # Invoke subrequest without individual transaction.
             resp, subrequest = request.follow_subrequest(subrequest,
@@ -103,10 +102,6 @@ def post_batch(request):
         except httpexceptions.HTTPException as e:
             error_msg = 'Failed batch subrequest'
             resp = errors.http_error(e, message=error_msg)
-        except Exception as e:
-            logger.error(e)
-            resp = errors.http_error(httpexceptions.HTTPInternalServerError())
-
         sublogger.bind(code=resp.status_code)
         sublogger.info('subrequest.summary')
 

--- a/cliquet/views/batch.py
+++ b/cliquet/views/batch.py
@@ -97,21 +97,21 @@ def post_batch(request):
                        method=subrequest.method)
 
         try:
-            subresponse, subrequest = request.follow_subrequest(subrequest)
-
+            # Invoke subrequest without individual transaction.
+            resp, subrequest = request.follow_subrequest(subrequest,
+                                                         use_tweens=False)
         except httpexceptions.HTTPException as e:
             error_msg = 'Failed batch subrequest'
-            subresponse = errors.http_error(e, message=error_msg)
+            resp = errors.http_error(e, message=error_msg)
         except Exception as e:
             logger.error(e)
-            subresponse = errors.http_error(
-                httpexceptions.HTTPInternalServerError())
+            resp = errors.http_error(httpexceptions.HTTPInternalServerError())
 
-        sublogger.bind(code=subresponse.status_code)
+        sublogger.bind(code=resp.status_code)
         sublogger.info('subrequest.summary')
 
-        subresponse = build_response(subresponse, subrequest)
-        responses.append(subresponse)
+        dict_resp = build_response(resp, subrequest)
+        responses.append(dict_resp)
 
     # Rebing batch request for summary
     logger.bind(path=batch.path,

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ PasteDeploy==1.5.2
 psycopg2==2.6.1
 pyramid==1.5.7
 pyramid-multiauth==0.5.0
+pyramid-tm==0.12
 python-dateutil==2.4.2
 raven==5.8.1
 redis==2.10.5
@@ -16,6 +17,7 @@ six==1.10.0
 SQLAlchemy==1.0.9
 statsd==3.2.1
 structlog==15.3.0
+transaction==1.4.4
 translationstring==1.3
 ujson==1.33
 venusian==1.0
@@ -24,3 +26,4 @@ Werkzeug==0.11
 wheel==0.24.0
 zope.deprecation==4.1.2
 zope.interface==4.1.3
+zope.sqlalchemy==0.7.6

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ REQUIREMENTS = [
     'cornice >= 1.1',  # Fix cache CORS
     'python-dateutil',
     'pyramid_multiauth >= 0.5',  # Pluggable authz
+    'pyramid_tm',
     'redis',  # Default backend
     'requests',
     'six',
@@ -34,6 +35,7 @@ if installed_with_pypy:
     POSTGRESQL_REQUIRES = [
         'SQLAlchemy',
         'psycopg2cffi>2.7.0',
+        'zope.sqlalchemy',
     ]
 else:
     # ujson is not pypy compliant, as it uses the CPython C API
@@ -41,6 +43,7 @@ else:
     POSTGRESQL_REQUIRES = [
         'SQLAlchemy',
         'psycopg2>2.5',
+        'zope.sqlalchemy',
     ]
 
 DEPENDENCY_LINKS = [

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ deps =
     nose
     psycopg2
     SQLAlchemy
+    zope.sqlalchemy
     raven
     statsd
     unittest2
@@ -29,6 +30,7 @@ deps =
     nose
     psycopg2
     SQLAlchemy
+    zope.sqlalchemy
     raven
     statsd
     webtest
@@ -55,6 +57,7 @@ deps =
     nose
     psycopg2cffi
     SQLAlchemy
+    zope.sqlalchemy
     raven
     statsd
     webtest


### PR DESCRIPTION
* [x] Switch to SQLA sessions
* [x] Plug SQLA session with pyramid transaction manager
* [x] Share session among backend instances
* [x] Change batch response content when one subrequest error occurs
* [x] Test that crash within request rollbacks global transaction
* [ ] ~~Two-phase commit accross backends ?~~ Session is shared accross backends if URL is the same