### PR TITLE
Fix PUT not using create() method in storage backend when tombstone exists (fixes #530)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,8 @@ This document describes changes between each past release.
 
 - Fix PostgreSQL error when deleting an empty collection in a protected
   resource (fixes #528)
+- Fix PUT not using ``create()`` method in storage backend when tombstone exists
+  (fixes #530)
 
 **Internal changes**
 

--- a/cliquet/tests/resource/test_record.py
+++ b/cliquet/tests/resource/test_record.py
@@ -63,6 +63,16 @@ class PutTest(BaseTest):
             self.resource.put()
             self.assertEqual(patched.call_count, 1)
 
+    def test_relies_on_collection_create_even_when_previously_deleted(self):
+        record = self.model.create_record({'field': 'value'})
+        self.resource.record_id = record['id']
+        self.resource.delete()['data']
+
+        self.resource.request.validated = {'data': {'field': 'new'}}
+        with mock.patch.object(self.model, 'create_record') as patched:
+            self.resource.put()
+            self.assertEqual(patched.call_count, 1)
+
     def test_replace_record_returns_updated_fields(self):
         self.resource.request.validated = {'data': {'field': 'new'}}
         result = self.resource.put()['data']

--- a/cliquet/tests/resource/test_views.py
+++ b/cliquet/tests/resource/test_views.py
@@ -40,7 +40,7 @@ class BaseResourcePermissionTest(BaseWebTest, unittest.TestCase):
         self.app.get(record_url, headers=self.headers, status=200)
         self.app.patch_json(record_url, body, headers=self.headers, status=200)
         self.app.delete(record_url, headers=self.headers, status=200)
-        self.app.put_json(record_url, body, headers=self.headers, status=200)
+        self.app.put_json(record_url, body, headers=self.headers, status=201)
         self.app.put_json(unknown_url, body, headers=self.headers, status=201)
 
 


### PR DESCRIPTION
Fixes the api-test as expected :)

@Natim r?