### PR TITLE
Expose the version protocol in the / endpoint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,7 +15,6 @@ This document describes changes between each past release.
 - Add the ``protocol_version`` to tell which protocol version is
   implemented by the service. (#324)
 
-
 **Internal changes**
 
 - Added a simple end-to-end test on a *Cliquet* sample application, using

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,10 @@ This document describes changes between each past release.
 * ``_since`` and ``_before`` now accepts an integer value between quotes ``"``,
   as it would be returned in the ``ETag`` response header.
 
+- Add the ``protocol_version`` to tell which protocol version is
+  implemented by the service. (#324)
+
+
 **Internal changes**
 
 - Added a simple end-to-end test on a *Cliquet* sample application, using

--- a/cliquet/__init__.py
+++ b/cliquet/__init__.py
@@ -20,8 +20,10 @@ from cliquet.utils import follow_subrequest
 # Module version, as defined in PEP-0396.
 __version__ = pkg_resources.get_distribution(__package__).version
 
-# The API version is derivated from the module version.
+# The API version, incremented when Python API has breaking change.
 API_VERSION = '%s' % __version__.split('.')[0]
+# The protocol version, incremented when HTTP API has breaking change.
+PROTOCOL_VERSION = API_VERSION
 
 
 DEFAULT_SETTINGS = {

--- a/cliquet/__init__.py
+++ b/cliquet/__init__.py
@@ -21,7 +21,7 @@ from cliquet.utils import follow_subrequest
 __version__ = pkg_resources.get_distribution(__package__).version
 
 # The API version is derivated from the module version.
-API_VERSION = '%s' % __version__.split('.')[0]
+API_VERSION = 'v%s' % __version__.split('.')[0]
 
 
 DEFAULT_SETTINGS = {

--- a/cliquet/__init__.py
+++ b/cliquet/__init__.py
@@ -21,7 +21,7 @@ from cliquet.utils import follow_subrequest
 __version__ = pkg_resources.get_distribution(__package__).version
 
 # The API version is derivated from the module version.
-API_VERSION = 'v%s' % __version__.split('.')[0]
+API_VERSION = '%s' % __version__.split('.')[0]
 
 
 DEFAULT_SETTINGS = {

--- a/cliquet/tests/test_views_hello.py
+++ b/cliquet/tests/test_views_hello.py
@@ -8,7 +8,7 @@ class HelloViewTest(BaseWebTest, unittest.TestCase):
     def test_returns_info_about_url_and_version(self):
         response = self.app.get('/')
         self.assertEqual(response.json['version'], "0.0.1")
-        self.assertEqual(response.json['api_version'], "2")
+        self.assertEqual(response.json['protocol'], "v2")
         self.assertEqual(response.json['url'], 'http://localhost/v0/')
         self.assertEqual(response.json['hello'], 'myapp')
         self.assertEqual(response.json['documentation'],

--- a/cliquet/tests/test_views_hello.py
+++ b/cliquet/tests/test_views_hello.py
@@ -8,7 +8,7 @@ class HelloViewTest(BaseWebTest, unittest.TestCase):
     def test_returns_info_about_url_and_version(self):
         response = self.app.get('/')
         self.assertEqual(response.json['version'], "0.0.1")
-        self.assertEqual(response.json['protocol'], "v2")
+        self.assertEqual(response.json['protocol_version'], "2")
         self.assertEqual(response.json['url'], 'http://localhost/v0/')
         self.assertEqual(response.json['hello'], 'myapp')
         self.assertEqual(response.json['documentation'],

--- a/cliquet/tests/test_views_hello.py
+++ b/cliquet/tests/test_views_hello.py
@@ -8,6 +8,7 @@ class HelloViewTest(BaseWebTest, unittest.TestCase):
     def test_returns_info_about_url_and_version(self):
         response = self.app.get('/')
         self.assertEqual(response.json['version'], "0.0.1")
+        self.assertEqual(response.json['api_version'], "2")
         self.assertEqual(response.json['url'], 'http://localhost/v0/')
         self.assertEqual(response.json['hello'], 'myapp')
         self.assertEqual(response.json['documentation'],

--- a/cliquet/views/hello.py
+++ b/cliquet/views/hello.py
@@ -13,7 +13,7 @@ def get_hello(request):
     data = dict(
         hello=project_name,
         version=settings['project_version'],
-        protocol=API_VERSION,
+        protocol_version=API_VERSION,
         url=request.route_url(hello.name),
         documentation=settings['project_docs']
     )

--- a/cliquet/views/hello.py
+++ b/cliquet/views/hello.py
@@ -1,6 +1,6 @@
 from pyramid.security import NO_PERMISSION_REQUIRED
 
-from cliquet import Service, API_VERSION
+from cliquet import Service, PROTOCOL_VERSION
 
 hello = Service(name="hello", path='/', description="Welcome")
 
@@ -13,7 +13,7 @@ def get_hello(request):
     data = dict(
         hello=project_name,
         version=settings['project_version'],
-        protocol_version=API_VERSION,
+        protocol_version=PROTOCOL_VERSION,
         url=request.route_url(hello.name),
         documentation=settings['project_docs']
     )

--- a/cliquet/views/hello.py
+++ b/cliquet/views/hello.py
@@ -13,7 +13,7 @@ def get_hello(request):
     data = dict(
         hello=project_name,
         version=settings['project_version'],
-        api_version=API_VERSION,
+        protocol=API_VERSION,
         url=request.route_url(hello.name),
         documentation=settings['project_docs']
     )

--- a/cliquet/views/hello.py
+++ b/cliquet/views/hello.py
@@ -1,6 +1,6 @@
 from pyramid.security import NO_PERMISSION_REQUIRED
 
-from cliquet import Service
+from cliquet import Service, API_VERSION
 
 hello = Service(name="hello", path='/', description="Welcome")
 
@@ -13,6 +13,7 @@ def get_hello(request):
     data = dict(
         hello=project_name,
         version=settings['project_version'],
+        api_version=API_VERSION,
         url=request.route_url(hello.name),
         documentation=settings['project_docs']
     )

--- a/cliquet_docs/api/utilities.rst
+++ b/cliquet_docs/api/utilities.rst
@@ -9,7 +9,7 @@ GET /
 The returned value is a JSON mapping containing:
 
 - ``hello``: the name of the service (e.g. ``"reading list"``)
-- ``api_version``: the cliquet protocol version (``"2"``)
+- ``protocol``: the cliquet protocol version (``"v2"``)
 - ``version``: complete version (``"X.Y.Z"``)
 - ``url``: absolute URI (without a trailing slash) of the API (*can be used by client to build URIs*)
 - ``eos``: date of end of support in ISO 8601 format (``"yyyy-mm-dd"``, undefined if unknown)

--- a/cliquet_docs/api/utilities.rst
+++ b/cliquet_docs/api/utilities.rst
@@ -9,6 +9,7 @@ GET /
 The returned value is a JSON mapping containing:
 
 - ``hello``: the name of the service (e.g. ``"reading list"``)
+- ``api_version``: the cliquet protocol version (``"2"``)
 - ``version``: complete version (``"X.Y.Z"``)
 - ``url``: absolute URI (without a trailing slash) of the API (*can be used by client to build URIs*)
 - ``eos``: date of end of support in ISO 8601 format (``"yyyy-mm-dd"``, undefined if unknown)

--- a/cliquet_docs/api/utilities.rst
+++ b/cliquet_docs/api/utilities.rst
@@ -10,7 +10,7 @@ The returned value is a JSON mapping containing:
 
 - ``hello``: the name of the service (e.g. ``"reading list"``)
 - ``protocol_version``: the cliquet protocol version (``"2"``)
-- ``version``: complete version (``"X.Y.Z"``)
+- ``version``: complete application/project version (``"X.Y.Z"``)
 - ``url``: absolute URI (without a trailing slash) of the API (*can be used by client to build URIs*)
 - ``eos``: date of end of support in ISO 8601 format (``"yyyy-mm-dd"``, undefined if unknown)
 - ``documentation``: The URL to the service documentation. (this document!)

--- a/cliquet_docs/api/utilities.rst
+++ b/cliquet_docs/api/utilities.rst
@@ -9,7 +9,7 @@ GET /
 The returned value is a JSON mapping containing:
 
 - ``hello``: the name of the service (e.g. ``"reading list"``)
-- ``protocol``: the cliquet protocol version (``"v2"``)
+- ``protocol_version``: the cliquet protocol version (``"2"``)
 - ``version``: complete version (``"X.Y.Z"``)
 - ``url``: absolute URI (without a trailing slash) of the API (*can be used by client to build URIs*)
 - ``eos``: date of end of support in ISO 8601 format (``"yyyy-mm-dd"``, undefined if unknown)


### PR DESCRIPTION
Currently, the version exposed in the / endpoint isn't the protocol version but the version of the application. As such, it's important to also provide the protocol version alongside the other information.

Protocol version could be the major version of cliquet.