### PR TITLE
Preparing release 2.10.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,12 @@ Changelog
 This document describes changes between each past release.
 
 
+2.11.0 (unreleased)
+-------------------
+
+- Nothing changed yet.
+
+
 2.10.0 (2015-10-30)
 -------------------
 
@@ -16,6 +22,7 @@ This document describes changes between each past release.
 - Follow redirections in batch subrequests (fixes #511)
 - When recreating a record that was previously deleted, status code is now ``201``
   (ref #530).
+
 
 **New features**
 
@@ -34,7 +41,6 @@ This document describes changes between each past release.
 - Delete tombstone when record is re-created (fixes #518)
 - Fix crash with empty body for PATCH (fixes #477, fixes #516)
 - Fix english typo in 404 error message (fixes #527)
-
 
 **Internal changes**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,10 +4,12 @@ Changelog
 This document describes changes between each past release.
 
 
-2.11.0 (unreleased)
+2.10.1 (2015-11-03)
 -------------------
 
-- Nothing changed yet.
+**Bug fixes**
+
+- Make sure read enpoint are activated in readonly mode. (#539)
 
 
 2.10.0 (2015-10-30)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ This document describes changes between each past release.
 
 **Bug fixes**
 
-- Make sure read enpoint are activated in readonly mode. (#539)
+- Make sure read enpoints (GET, OPTIONS, HEAD) are activated in readonly mode. (#539)
 
 
 2.10.0 (2015-10-30)
@@ -24,7 +24,6 @@ This document describes changes between each past release.
 - Follow redirections in batch subrequests (fixes #511)
 - When recreating a record that was previously deleted, status code is now ``201``
   (ref #530).
-
 
 **New features**
 

--- a/cliquet/resource/viewset.py
+++ b/cliquet/resource/viewset.py
@@ -153,7 +153,9 @@ class ViewSet(object):
         Uses the settings to tell so.
         """
         readonly_enabled = asbool(settings.get('readonly'))
-        if readonly_enabled and method not in self.readonly_methods:
+        readonly_method = method.lower() in [m.lower() for m in
+                                             self.readonly_methods]
+        if readonly_enabled and not readonly_method:
             return False
 
         setting_enabled = '%s_%s_%s_enabled' % (

--- a/cliquet/tests/resource/test_viewset.py
+++ b/cliquet/tests/resource/test_viewset.py
@@ -304,6 +304,33 @@ class ViewSetTest(unittest.TestCase):
                                                  config)
         self.assertFalse(is_enabled)
 
+    def test_is_endpoint_enabled_returns_true_for_get_if_readonly(self):
+        viewset = ViewSet()
+        config = {
+            'readonly': True
+        }
+        is_enabled = viewset.is_endpoint_enabled('record', 'fake', 'get',
+                                                 config)
+        self.assertTrue(is_enabled)
+
+    def test_is_endpoint_enabled_returns_true_for_options_if_readonly(self):
+        viewset = ViewSet()
+        config = {
+            'readonly': True
+        }
+        is_enabled = viewset.is_endpoint_enabled('record', 'fake', 'options',
+                                                 config)
+        self.assertTrue(is_enabled)
+
+    def test_is_endpoint_enabled_returns_true_for_head_if_readonly(self):
+        viewset = ViewSet()
+        config = {
+            'readonly': True
+        }
+        is_enabled = viewset.is_endpoint_enabled('record', 'fake', 'head',
+                                                 config)
+        self.assertTrue(is_enabled)
+
 
 class ProtectedViewSetTest(unittest.TestCase):
     def test_permission_dynamic_is_set_by_default(self):

--- a/cliquet_docs/conf.py
+++ b/cliquet_docs/conf.py
@@ -68,7 +68,7 @@ copyright = u'2015, Mozilla Services — Da French Team'
 # The short X.Y version.
 version = '2.10'
 # The full version, including alpha/beta/rc tags.
-release = '2.10.0'
+release = '2.10.1'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ structlog==15.3.0
 translationstring==1.3
 ujson==1.33
 venusian==1.0
-WebOb==1.5.0
+WebOb==1.5.1
 Werkzeug==0.10.4
 wheel==0.24.0
 zope.deprecation==4.1.2

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ ENTRY_POINTS = {
 
 
 setup(name='cliquet',
-      version='2.10.0',
+      version='2.10.1',
       description='Micro service API toolkit',
       long_description=README + "\n\n" + CHANGELOG + "\n\n" + CONTRIBUTORS,
       license='Apache License (2.0)',


### PR DESCRIPTION
### Release 2.10 will land without SQLAchemy (on master).

**Tooling requirements**
* ``pip install zest.releaser[recommended]`` (Install zest.releaser, wheel and twine)

**Step 1**
```
$ git co -b prepare-X.Y.Z
$ prerelease
$ vim cliquet_docs/conf.py
$ rm -fr .venv/
$ make build-requirements
$ git ci -a --amend
$ git push origin prepare-X.Y.Z
```
* [x] Update Contributors file ``git shortlog -sne | awk '{$1=""; sub(" ", ""); print}' | awk -F'<' '!x[$1]++' | awk -F'<' '!x[$2]++' | sort``
* [x] Merge remaining pull requests
* [x] Update changelog
* [x] Update version in ``cliquet_docs/conf.py``
* [x] Update known good set of dependencies in requirements.txt

**Step 2: Do not merge**
```
$ release
$ git co master
$ git cherry-pick <CHANGELOG update commit>
$ postrelease
```
* [x] Tag vX.Y.Z
* [x] Publish on Pypi

**Step 3**
* [x] Close milestone in Github
* [x] Create next milestone in Github
* [x] Add entry in Github release page
* [ ] Configure the version in ReadTheDocs
* [ ] Send mail to ML
