### PR TITLE
Fix crash with Redis backend if record parent/id is unicode (fixes #556)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ This document describes changes between each past release.
 - Add the ``protocol_version`` to tell which protocol version is
   implemented by the service. (#324)
 
+**Bug fixes**
+
+- Fix crash with Redis backend if record parent/id is unicode (fixes #556)
+
 **Internal changes**
 
 - Added a simple end-to-end test on a *Cliquet* sample application, using

--- a/cliquet/storage/redis.py
+++ b/cliquet/storage/redis.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 from functools import wraps
 
 import redis

--- a/cliquet/tests/test_storage.py
+++ b/cliquet/tests/test_storage.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import time
 
 import mock
@@ -231,6 +232,10 @@ class BaseTestStorage(object):
     def test_create_uses_the_resource_id_generator(self):
         record = self.create_record(id_generator=lambda: RECORD_ID)
         self.assertEquals(record['id'], RECORD_ID)
+
+    def test_create_supports_unicode_for_parent_and_id(self):
+        unicode_id = u'Rémy'
+        self.create_record(parent_id=unicode_id, collection_id=unicode_id)
 
     def test_create_does_not_overwrite_the_provided_id(self):
         record = self.record.copy()


### PR DESCRIPTION
@almet  r?