### PR TITLE
Refactor Redis client instantiation (fixes #567)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,6 +44,7 @@ This document describes changes between each past release.
 - Added a simple end-to-end test on a *Cliquet* sample application, using
   `Loads <http://github.com/loads/>`_ (fixes #512)
 - Switched to SQLAlchemy sessions instead of raw connections and cursors (#510)
+- Refactor Redis clients instantiation to avoid repeated defaults (#567, #568)
 
 
 2.10.2 (2015-11-10)

--- a/cliquet/tests/test_cache.py
+++ b/cliquet/tests/test_cache.py
@@ -176,7 +176,7 @@ class RedisCacheTest(BaseTestCache, unittest.TestCase):
         config.add_settings({'cache_url': 'redis://:secret@peer.loc:4444/7'})
         backend = self.backend.load_from_config(config)
         self.assertDictEqual(
-            backend._client.connection_pool.connection_kwargs,
+            backend.settings,
             {'host': 'peer.loc', 'password': 'secret', 'db': 7, 'port': 4444})
 
 

--- a/cliquet/tests/test_listeners.py
+++ b/cliquet/tests/test_listeners.py
@@ -1,16 +1,17 @@
 # -*- coding: utf-8 -*-
+import json
+import uuid
+from contextlib import contextmanager
+from datetime import datetime
+
 import mock
 from pyramid import testing
-import uuid
-import redis
-import json
-from datetime import datetime
-from contextlib import contextmanager
 
 from cliquet import initialization
 from cliquet.events import ResourceChanged, ACTIONS
 from cliquet.listeners import ListenerBase
-from .support import unittest
+from cliquet.storage.redis import create_from_config
+from cliquet.tests.support import unittest
 
 
 class ListenerSetupTest(unittest.TestCase):
@@ -70,9 +71,9 @@ class ListenerCalledTest(unittest.TestCase):
 
     def setUp(self):
         self.config = testing.setUp()
-        pool = redis.BlockingConnectionPool(max_connections=1,
-                                            host='localhost', port=6379, db=0)
-        self._redis = redis.StrictRedis(connection_pool=pool)
+        self.config.add_settings({'events_pool_size': 1,
+                                  'events_url': 'redis://localhost:6379/0'})
+        self._redis = create_from_config(self.config, prefix='events_')
         self._size = 0
 
     def _save_redis(self):

--- a/cliquet/tests/test_permission.py
+++ b/cliquet/tests/test_permission.py
@@ -456,7 +456,7 @@ class RedisPermissionTest(BaseTestPermission, unittest.TestCase):
         config.add_settings({'permission_url': 'redis://:pass@db.loc:1234/5'})
         backend = self.backend.load_from_config(config)
         self.assertDictEqual(
-            backend._client.connection_pool.connection_kwargs,
+            backend.settings,
             {'host': 'db.loc', 'password': 'pass', 'db': 5, 'port': 1234})
 
 

--- a/cliquet/tests/test_storage.py
+++ b/cliquet/tests/test_storage.py
@@ -977,7 +977,7 @@ class RedisStorageTest(MemoryStorageTest, unittest.TestCase):
         config.add_settings({'storage_url': 'redis://:blah@store.loc:7777/6'})
         backend = self.backend.load_from_config(config)
         self.assertDictEqual(
-            backend._client.connection_pool.connection_kwargs,
+            backend.settings,
             {'host': 'store.loc', 'password': 'blah', 'db': 6, 'port': 7777})
 
     def test_backend_error_provides_original_exception(self):


### PR DESCRIPTION
* [x] Refactor Redis client instantiation to avoid duplicated defaults
* [x] Add settings property to avoid introspection of private member in tests (fixes #567)

@tarekziade r?