### PR TITLE
Add pool with max_backlog option (fixes #509)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,8 @@ This document describes changes between each past release.
 - New settings for backends when using PostgreSQL: ``*_pool_maxoverflow``,
   ``*_pool_recycle``, ``*_pool_timeout`` to control connections pool
   behaviour.
+- Add custom pool supporting a ``max_backlog`` parameter that limits the
+  number of threads waiting for a connection (#509)
 
 **Bug fixes**
 

--- a/cliquet/cache/postgresql/__init__.py
+++ b/cliquet/cache/postgresql/__init__.py
@@ -38,9 +38,15 @@ class Cache(CacheBase):
 
         cliquet.cache_pool_size = 10
         cliquet.cache_maxoverflow = 10
+        cliquet.cache_max_backlog = -1
         cliquet.cache_pool_recycle = -1
         cliquet.cache_pool_timeout = 30
-        cliquet.cache_poolclass = sqlalchemy.pool.QueuePool
+        cliquet.cache_poolclass = cliquet.storage.postgresql.pool.QueuePoolWithMaxBacklog
+
+    The ``max_backlog``  limits the number of threads that can be in the queue
+    waiting for a connection.  Once this limit has been reached, any further
+    attempts to acquire a connection will be rejected immediately, instead of
+    locking up all threads by keeping them waiting in the queue.
 
     See `dedicated section in SQLAlchemy documentation
     <http://docs.sqlalchemy.org/en/rel_1_0/core/engines.html>`_
@@ -53,7 +59,7 @@ class Cache(CacheBase):
         of connections used in a multi-process deployment.
 
     :noindex:
-    """
+    """  # NOQA
     def __init__(self, client, *args, **kwargs):
         super(Cache, self).__init__(*args, **kwargs)
         self.client = client

--- a/cliquet/permission/postgresql/__init__.py
+++ b/cliquet/permission/postgresql/__init__.py
@@ -39,9 +39,15 @@ class Permission(PermissionBase):
 
         cliquet.permission_pool_size = 10
         cliquet.permission_maxoverflow = 10
+        cliquet.permission_max_backlog = -1
         cliquet.permission_pool_recycle = -1
         cliquet.permission_pool_timeout = 30
-        cliquet.permission_poolclass = sqlalchemy.pool.QueuePool
+        cliquet.cache_poolclass = cliquet.storage.postgresql.pool.QueuePoolWithMaxBacklog
+
+    The ``max_backlog``  limits the number of threads that can be in the queue
+    waiting for a connection.  Once this limit has been reached, any further
+    attempts to acquire a connection will be rejected immediately, instead of
+    locking up all threads by keeping them waiting in the queue.
 
     See `dedicated section in SQLAlchemy documentation
     <http://docs.sqlalchemy.org/en/rel_1_0/core/engines.html>`_
@@ -54,7 +60,7 @@ class Permission(PermissionBase):
         of connections used in a multi-process deployment.
 
     :noindex:
-    """
+    """  # NOQA
     def __init__(self, client, *args, **kwargs):
         super(Permission, self).__init__(*args, **kwargs)
         self.client = client

--- a/cliquet/storage/postgresql/__init__.py
+++ b/cliquet/storage/postgresql/__init__.py
@@ -44,9 +44,15 @@ class Storage(StorageBase):
 
         cliquet.storage_pool_size = 10
         cliquet.storage_maxoverflow = 10
+        cliquet.storage_max_backlog = -1
         cliquet.storage_pool_recycle = -1
         cliquet.storage_pool_timeout = 30
-        cliquet.storage_poolclass = sqlalchemy.pool.QueuePool
+        cliquet.cache_poolclass = cliquet.storage.postgresql.pool.QueuePoolWithMaxBacklog
+
+    The ``max_backlog``  limits the number of threads that can be in the queue
+    waiting for a connection.  Once this limit has been reached, any further
+    attempts to acquire a connection will be rejected immediately, instead of
+    locking up all threads by keeping them waiting in the queue.
 
     See `dedicated section in SQLAlchemy documentation
     <http://docs.sqlalchemy.org/en/rel_1_0/core/engines.html>`_
@@ -58,7 +64,7 @@ class Storage(StorageBase):
         recommended to allow load balancing, replication or limit the number
         of connections used in a multi-process deployment.
 
-    """
+    """  # NOQA
 
     schema_version = 8
 

--- a/cliquet/storage/postgresql/client.py
+++ b/cliquet/storage/postgresql/client.py
@@ -88,7 +88,8 @@ def create_from_config(config, prefix=''):
 
     # Initialize SQLAlchemy engine from settings.
     poolclass_key = prefix + 'poolclass'
-    settings.setdefault(poolclass_key, 'sqlalchemy.pool.QueuePool')
+    settings.setdefault(poolclass_key, ('cliquet.storage.postgresql.'
+                                        'pool.QueuePoolWithMaxBacklog'))
     settings[poolclass_key] = config.maybe_dotted(settings[poolclass_key])
     engine = sqlalchemy.engine_from_config(settings, prefix=prefix, url=url)
 

--- a/cliquet/storage/postgresql/pool.py
+++ b/cliquet/storage/postgresql/pool.py
@@ -1,0 +1,55 @@
+from sqlalchemy.util.queue import Queue
+from sqlalchemy.pool import QueuePool
+
+
+class _QueueWithMaxBacklog(Queue):
+    """SQLAlchemy Queue subclass with a limit on the length of the backlog.
+
+    This base Queue class sets no limit on the number of threads that can be
+    simultaneously blocked waiting for an item on the queue.  This class
+    adds a "max_backlog" parameter that can be used to bound this number.
+    """
+
+    def __init__(self, maxsize=0, max_backlog=-1):
+        self.max_backlog = max_backlog
+        self.cur_backlog = 0
+        Queue.__init__(self, maxsize)
+
+    def get(self, block=True, timeout=None):
+        # The SQLAlchemy Queue class uses a re-entrant mutext by default,
+        # so it's safe to acquire it both here and in the superclass method.
+        with self.mutex:
+            self.cur_backlog += 1
+            try:
+                if self.max_backlog >= 0:
+                    if self.cur_backlog > self.max_backlog:
+                        block = False
+                        timeout = None
+                return Queue.get(self, block, timeout)
+            finally:
+                self.cur_backlog -= 1
+
+
+class QueuePoolWithMaxBacklog(QueuePool):
+    """An SQLAlchemy QueuePool with a limit on the length of the backlog.
+
+    The base QueuePool class sets no limit on the number of threads that can
+    be simultaneously attempting to connect to the database.  This means that
+    a misbehaving database can easily lock up all threads by keeping them
+    waiting in the queue.
+
+    This QueuePool subclass provides a "max_backlog" that limits the number
+    of threads that can be in the queue waiting for a connection.  Once this
+    limit has been reached, any further attempts to acquire a connection will
+    be rejected immediately.
+    """
+
+    def __init__(self, creator, max_backlog=-1, **kwds):
+        QueuePool.__init__(self, creator, **kwds)
+        self._pool = _QueueWithMaxBacklog(self._pool.maxsize, max_backlog)
+
+    def recreate(self):
+        new_self = QueuePool.recreate(self)
+        new_self._pool = _QueueWithMaxBacklog(self._pool.maxsize,
+                                              self._pool.max_backlog)
+        return new_self

--- a/cliquet/tests/test_storage_pool.py
+++ b/cliquet/tests/test_storage_pool.py
@@ -1,0 +1,70 @@
+import time
+import threading
+
+from pyramid import testing
+
+from .support import unittest, skip_if_no_postgresql
+
+
+@skip_if_no_postgresql
+class QueuePoolWithMaxBacklogTest(unittest.TestCase):
+    def setUp(self):
+        from cliquet.storage.postgresql.client import create_from_config
+
+        self.connections = []
+        self.errors = []
+
+        config = testing.setUp(settings={
+            'pooltest_url': 'sqlite:///:memory:',
+            'pooltest_pool_size': 2,
+            'pooltest_pool_timeout': 1,
+            'pooltest_max_backlog': 2,
+            'pooltest_max_overflow': 1,
+        })
+        # Create an engine with known pool parameters.
+        # Use create_from_config() to make sure it is used by default
+        # and handles parameters.
+        client = create_from_config(config, prefix='pooltest_')
+        self.engine = client._engine
+
+        # The size of the pool is two, so we can take
+        # two connections right away without any error.
+        self.take_connection()
+        self.take_connection()
+        # The pool allows an overflow of 1, so we can
+        # take another, ephemeral connection without any error.
+        self.take_connection()
+        self.assertEquals(len(self.connections), 3)
+        self.assertEquals(len(self.errors), 0)
+
+    def take_connection(self):
+        try:
+            self.connections.append(self.engine.connect())
+        except Exception, e:
+            self.errors.append(e)
+
+    def test_max_overflow_and_max_backlog(self):
+        # The pool allows a backlog of 2, so we can
+        # spawn two threads that will block waiting for a connection.
+        thread1 = threading.Thread(target=self.take_connection)
+        thread1.start()
+        thread2 = threading.Thread(target=self.take_connection)
+        thread2.start()
+        self.assertEquals(len(self.connections), 3)
+        self.assertEquals(len(self.errors), 0)
+
+        # The pool is now exhausted and at maximum backlog.
+        # Trying to take another connection fails immediately.
+        t1 = time.time()
+        self.take_connection()
+        t2 = time.time()
+        self.assertEquals(len(self.connections), 3)
+        # This checks that it failed immediately rather than timing out.
+        self.assertTrue(t2 - t1 < 0.9)
+        self.assertTrue(len(self.errors) >= 1)
+
+        # And eventually, the blocked threads will time out.
+        thread1.join()
+        thread2.join()
+        self.assertEquals(len(self.connections), 3)
+        self.assertEquals(len(self.errors), 3)

--- a/cliquet/tests/test_storage_pool.py
+++ b/cliquet/tests/test_storage_pool.py
@@ -25,7 +25,8 @@ class QueuePoolWithMaxBacklogTest(unittest.TestCase):
         # Use create_from_config() to make sure it is used by default
         # and handles parameters.
         client = create_from_config(config, prefix='pooltest_')
-        self.engine = client._engine
+        session = client.session_factory()
+        self.engine = session.get_bind()
 
     def take_connection(self):
         try:


### PR DESCRIPTION
This code from imported from Mozilla Services Sync.
See mozilla-services/server-syncstorage@f93ca85

*Note: Cliquet is licensed under Apache and Sync is under MPL*

@Natim r?
@tarekziade, @rfk  comments?