### PR TITLE
Add list of impacted records on ResourceChanged event (fixes #501)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,6 +35,9 @@ This document describes changes between each past release.
   behaviour.
 - Add custom pool supporting a ``max_backlog`` parameter that limits the
   number of threads waiting for a connection (#509)
+- Add ``impacted_records`` attribute on ``ResourceChanged`` event (#501)
+  This also allows listeners to react on particular field change, since old and
+  new version of records is provided.
 
 **Bug fixes**
 

--- a/cliquet/events.py
+++ b/cliquet/events.py
@@ -10,7 +10,8 @@ ACTIONS = Enum(CREATE='create',
 class ResourceChanged(object):
     """Triggered when a resource is changed.
     """
-    def __init__(self, action, resource, request):
+    def __init__(self, action, resource, impacted_records, request):
+        self.impacted_records = impacted_records
         self.request = request
         service = current_service(request)
         resource_name = service.viewset.get_name(resource.__class__)

--- a/cliquet/resource/__init__.py
+++ b/cliquet/resource/__init__.py
@@ -391,7 +391,7 @@ class UserResource(object):
         self._add_timestamp_header(self.request.response, timestamp=timestamp)
 
         action = existing and ACTIONS.UPDATE or ACTIONS.CREATE
-        return self.postprocess(record, action=action)
+        return self.postprocess(record, action=action, old=existing)
 
     def patch(self):
         """Record ``PATCH`` endpoint: modify a record and return its
@@ -416,8 +416,8 @@ class UserResource(object):
             :meth:`cliquet.resource.UserResource.process_record`.
         """
         self._raise_400_if_invalid_id(self.record_id)
-        old_record = self._get_record_or_404(self.record_id)
-        self._raise_412_if_modified(old_record)
+        existing = self._get_record_or_404(self.record_id)
+        self._raise_412_if_modified(existing)
 
         try:
             # `data` attribute may not be present if only perms are patched.
@@ -431,16 +431,16 @@ class UserResource(object):
             }
             raise_invalid(self.request, **error_details)
 
-        updated = self.apply_changes(old_record, changes=changes)
+        updated = self.apply_changes(existing, changes=changes)
 
         record_id = updated.setdefault(self.model.id_field,
                                        self.record_id)
         self._raise_400_if_id_mismatch(record_id, self.record_id)
 
-        new_record = self.process_record(updated, old=old_record)
+        new_record = self.process_record(updated, old=existing)
 
         changed_fields = [k for k in changes.keys()
-                          if old_record.get(k) != new_record.get(k)]
+                          if existing.get(k) != new_record.get(k)]
 
         # Save in storage if necessary.
         if changed_fields or self.force_patch_update:
@@ -455,7 +455,7 @@ class UserResource(object):
             # Behave as if storage would have added `id` and `last_modified`.
             for extra_field in [self.model.modified_field,
                                 self.model.id_field]:
-                new_record[extra_field] = old_record[extra_field]
+                new_record[extra_field] = existing[extra_field]
 
         # Adjust response according to ``Response-Behavior`` header
         body_behavior = self.request.headers.get('Response-Behavior', 'full')
@@ -472,10 +472,10 @@ class UserResource(object):
             data = new_record
 
         timestamp = new_record.get(self.model.modified_field,
-                                   old_record[self.model.modified_field])
+                                   existing[self.model.modified_field])
         self._add_timestamp_header(self.request.response, timestamp=timestamp)
 
-        return self.postprocess(data, action=ACTIONS.UPDATE)
+        return self.postprocess(data, action=ACTIONS.UPDATE, old=existing)
 
     def delete(self):
         """Record ``DELETE`` endpoint: delete a record and return it.
@@ -574,7 +574,7 @@ class UserResource(object):
             for field, error in e.asdict().items():
                 raise_invalid(self.request, name=field, description=error)
 
-    def postprocess(self, result, action=ACTIONS.READ):
+    def postprocess(self, result, action=ACTIONS.READ, old=None):
         body = {
             'data': result
         }
@@ -583,8 +583,17 @@ class UserResource(object):
         # when it's added
         if action != ACTIONS.READ:
             # the collection has been changed
+            if not isinstance(result, list):
+                result = [result]
+            impacted = {}
+            if action == ACTIONS.CREATE:
+                impacted = [{'new': r} for r in result]
+            elif action == ACTIONS.DELETE:
+                impacted = [{'old': r} for r in result]
+            elif action == ACTIONS.UPDATE:
+                impacted = [{'new': r, 'old': old} for r in result]
             try:
-                event = ResourceChanged(action, self, self.request)
+                event = ResourceChanged(action, self, impacted, self.request)
                 self.request.registry.notify(event)
             except Exception:
                 logger.error("Unable to notify", exc_info=True)
@@ -1060,15 +1069,17 @@ class ShareableResource(UserResource):
         In the protocol, it was decided that ``permissions`` would reside
         outside the ``data`` attribute.
         """
-        result = super(ShareableResource, self).postprocess(result, **kwargs)
-        if isinstance(result['data'], list):
-            # collection endpoint.
-            return result
+        body = {}
 
-        perms = result['data'].pop(self.model.permissions_field, None)
-        if perms is not None:
-            result['permissions'] = {k: list(p) for k, p in perms.items()}
-        return result
+        if not isinstance(result, list):
+            # record endpoint.
+            perms = result.pop(self.model.permissions_field, None)
+            if perms is not None:
+                body['permissions'] = {k: list(p) for k, p in perms.items()}
+
+        data = super(ShareableResource, self).postprocess(result, **kwargs)
+        body.update(data)
+        return body
 
 
 @six.add_metaclass(DeprecatedMeta)

--- a/cliquet/tests/test_listeners.py
+++ b/cliquet/tests/test_listeners.py
@@ -102,7 +102,7 @@ class ListenerCalledTest(unittest.TestCase):
     def test_redis_is_notified(self):
         with self.redis_listening():
             # let's trigger an event
-            event = ResourceChanged('create', Resource(), Request())
+            event = ResourceChanged('create', Resource(), [], Request())
             self.notify(event)
             self.assertTrue(self.has_redis_changed())
 
@@ -117,7 +117,7 @@ class ListenerCalledTest(unittest.TestCase):
             res = Resource()
             # date time objects cannot be dumped
             res.timestamp = datetime.now()
-            event2 = ResourceChanged('create', res, Request())
+            event2 = ResourceChanged('create', res, [], Request())
             self.notify(event2)
             self.assertFalse(self.has_redis_changed())
 
@@ -127,7 +127,7 @@ class ListenerCalledTest(unittest.TestCase):
             self._save_redis()
 
             with broken_redis():
-                event = ResourceChanged('create', Resource(), Request())
+                event = ResourceChanged('create', Resource(), [], Request())
                 self.config.registry.notify(event)
 
             self.assertFalse(self.has_redis_changed())

--- a/cliquet_docs/reference/notifications.rst
+++ b/cliquet_docs/reference/notifications.rst
@@ -43,6 +43,21 @@ the following information:
 - **<matchdict value>**: every value matched by each URL pattern name (see
   `Pyramid request matchdict <http://docs.pylonsproject.org/projects/pyramid/en/latest/glossary.html#term-matchdict>`_)
 
+And provides the list of affected records in the ``impacted_records`` attribute.
+This list contains dictionnaries with ``new`` and ``old`` keys. For creation
+events, only ``new`` is provided. For deletion events, only ``old`` is provided.
+This also allows listeners to react on particular field change or handle *diff*
+between versions.
+
+Example, when deleting a collection:
+
+::
+
+    >>> event.impacted_records
+    [{'old': {'deleted': True, 'last_modified': 1447240896769, 'id': u'a1f4af60-ddf5-4c49-933f-4cfeff18ad07'}},
+     {'old': {'deleted': True, 'last_modified': 1447240896770, 'id': u'7a6916aa-0ea1-42a7-9741-c24fe13cb70b'}}]
+
+
 Event listeners
 ---------------
 


### PR DESCRIPTION
This allowed me to implement a very nice demo of live sync on a map with cliquet-pusher :) 

This also allows listeners to react on particular field change, since old and new version of records is provided.

Note: the `permission` attribute is not provided, only the content of `data`.

Question: should the list of impacted records be in the event `payload` attribute instead of being a member?

Thoughts?
