### PR TITLE
Load plugins after setting up authn/authz

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,16 @@ This document describes changes between each past release.
 2.12.0 (unreleased)
 -------------------
 
-- Nothing changed yet.
+**Breaking changes**
+
+- When using *cliquet-fxa*, the setting ``multiauth.policy.fxa.use`` must now
+  be explicitly set to ``cliquet_fxa.authentication.FxAOAuthAuthenticationPolicy``
+
+
+**Bug fixes**
+
+- Include plugins after setting up components (like authn/authz) so that plugins
+  can register views with permissions checking
 
 
 2.11.0 (2015-11-17)

--- a/cliquet/__init__.py
+++ b/cliquet/__init__.py
@@ -126,11 +126,6 @@ def includeme(config):
     # Per-request transaction.
     config.include("pyramid_tm")
 
-    # Include cliquet plugins after init, unlike pyramid includes.
-    includes = aslist(settings['includes'])
-    for app in includes:
-        config.include(app)
-
     # Add CORS settings to the base cliquet Service class.
     Service.init_from_settings(settings)
 
@@ -138,6 +133,11 @@ def includeme(config):
     for step in aslist(settings['initialization_sequence']):
         step_func = config.maybe_dotted(step)
         step_func(config)
+
+    # Include cliquet plugins after init, unlike pyramid includes.
+    includes = aslist(settings['includes'])
+    for app in includes:
+        config.include(app)
 
     # # Show settings to output.
     # for key, value in settings.items():

--- a/cliquet/tests/testplugin/__init__.py
+++ b/cliquet/tests/testplugin/__init__.py
@@ -1,0 +1,17 @@
+from cliquet import Service
+from cliquet.authorization import RouteFactory
+
+
+attachment = Service(name='attachment',
+                     description='Attach file to record',
+                     path='/attachment',
+                     factory=RouteFactory)
+
+
+@attachment.post(permission='attach')
+def attachment_post(request):
+    return {"ok": True}
+
+
+def includeme(config):
+    config.add_cornice_service(attachment)


### PR DESCRIPTION
While developing kinto-attachment, we realized that if plugins were included
before setting-up authn/authz, their views could not be protected by permissions.

For example, when a plugin defines a service like this in a view:

```python

    upload = Service(name="upload",
                     path="/upload",
                     description="",
                     factory=RouteFactory)
    @upload.get(permission="upload")
    def upload_get(request):
        return {"ok": True}

```

The factory is taken into account, but the authorization policy was never
called!

With this change, the plugins are included after ``cliquet.initialization.setup_authentication()``. Thus after ``config.include("pyramid_multiauth")`` thus after setting
up the authorization policy from conf ``multiauth.authorization_policy``.

The side-effet of this is that plugins cannot set default settings regarding auth.
It was the case of *cliquet-fxa* which defines an implicit setting ``multiauth.policy.fxa.use`` that allowed to just to specify ``fxa`` in the ``multiauth.policies`` setting.

The setting ``multiauth.policy.fxa.use`` must now be defined explicitly.

------------

There might be alternative within pyramid for an authorization policy to be applied on every view registered, but I could not find it. I thought it could also come from cornice, but could not find anything explicit in the code base.

@tarekziade @almet @Natim thoughts?