### PR TITLE
rename "hello" to "project_name"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,10 @@ This document describes changes between each past release.
 2.12.0 (unreleased)
 -------------------
 
+**Protocol**
+
+- ``hello`` was renamed ``name`` on the hello page property (#595),
+
 **Breaking changes**
 
 - When using *cliquet-fxa*, the setting ``multiauth.policy.fxa.use`` must now

--- a/cliquet/tests/test_views_batch.py
+++ b/cliquet/tests/test_views_batch.py
@@ -46,7 +46,7 @@ class BatchViewTest(BaseWebTest, unittest.TestCase):
         hello = resp.json['responses'][0]
         self.assertEqual(hello['path'], '/v0/')
         self.assertEqual(hello['status'], 200)
-        self.assertEqual(hello['body']['hello'], 'myapp')
+        self.assertEqual(hello['body']['name'], 'myapp')
         self.assertIn('application/json', hello['headers']['Content-Type'])
 
     def test_empty_response_body_with_head(self):
@@ -88,7 +88,7 @@ class BatchViewTest(BaseWebTest, unittest.TestCase):
         hello = resp.json['responses'][0]
         self.assertEqual(hello['path'], '/v0/')
         self.assertEqual(hello['status'], 200)
-        self.assertEqual(hello['body']['hello'], 'myapp')
+        self.assertEqual(hello['body']['name'], 'myapp')
         self.assertIn('application/json', hello['headers']['Content-Type'])
 
     def test_redirect_responses_are_followed(self):

--- a/cliquet/tests/test_views_hello.py
+++ b/cliquet/tests/test_views_hello.py
@@ -10,7 +10,7 @@ class HelloViewTest(BaseWebTest, unittest.TestCase):
         self.assertEqual(response.json['version'], "0.0.1")
         self.assertEqual(response.json['protocol_version'], "2")
         self.assertEqual(response.json['url'], 'http://localhost/v0/')
-        self.assertEqual(response.json['hello'], 'myapp')
+        self.assertEqual(response.json['name'], 'myapp')
         self.assertEqual(response.json['documentation'],
                          'https://cliquet.rtfd.org/')
 

--- a/cliquet/views/hello.py
+++ b/cliquet/views/hello.py
@@ -11,7 +11,7 @@ def get_hello(request):
     settings = request.registry.settings
     project_name = settings['project_name']
     data = dict(
-        hello=project_name,
+        name=project_name,
         version=settings['project_version'],
         protocol_version=PROTOCOL_VERSION,
         url=request.route_url(hello.name),

--- a/cliquet_docs/api/utilities.rst
+++ b/cliquet_docs/api/utilities.rst
@@ -8,7 +8,7 @@ GET /
 
 The returned value is a JSON mapping containing:
 
-- ``hello``: the name of the service (e.g. ``"reading list"``)
+- ``name``: the name of the service (e.g. ``"reading list"``)
 - ``protocol_version``: the cliquet protocol version (``"2"``)
 - ``version``: complete application/project version (``"X.Y.Z"``)
 - ``url``: absolute URI (without a trailing slash) of the API (*can be used by client to build URIs*)


### PR DESCRIPTION
see https://github.com/mozilla-services/cliquet/blob/master/cliquet/views/hello.py#L14

it seems to be clearer to rename it to project_name
