### PR TITLE
Keep last modified

### DIFF
--- a/cliquet/resource/__init__.py
+++ b/cliquet/resource/__init__.py
@@ -509,6 +509,7 @@ class UserResource(object):
         .. code-block:: python
 
             def process_record(self, new, old=None):
+                new = super(MyResource, self).process_record(new, old)
                 version = old['version'] if old else 0
                 new['version'] = version + 1
                 return new
@@ -520,6 +521,7 @@ class UserResource(object):
             from cliquet.errors import raise_invalid
 
             def process_record(self, new, old=None):
+                new = super(MyResource, self).process_record(new, old)
                 if new['browser'] not in request.headers['User-Agent']:
                     raise_invalid(self.request, name='browser', error='Wrong')
                 return new

--- a/cliquet/resource/__init__.py
+++ b/cliquet/resource/__init__.py
@@ -495,8 +495,7 @@ class UserResource(object):
         # Retreive the last_modified information from a querystring if present.
         last_modified = self.request.GET.get('last_modified')
 
-        deleted = self.model.delete_record(
-            record, last_modified=last_modified)
+        deleted = self.model.delete_record(record, last_modified=last_modified)
         return self.postprocess(deleted, action=ACTIONS.DELETE)
 
     #
@@ -537,8 +536,8 @@ class UserResource(object):
 
         # Drop the new last_modified if lesser or equal to the old one.
         new_last_modified = new.get(self.model.modified_field)
-        if (new_last_modified and
-                new_last_modified <= old[self.model.modified_field]):
+        is_greater = new_last_modified <= old[self.model.modified_field]
+        if (new_last_modified and is_greater):
             del new[self.model.modified_field]
 
         return new

--- a/cliquet/resource/__init__.py
+++ b/cliquet/resource/__init__.py
@@ -531,11 +531,13 @@ class UserResource(object):
         :returns: the processed record.
         :rtype: dict
         """
-        if old is None or self.model.modified_field not in old:
+        new_last_modified = new.get(self.model.modified_field)
+        not_specified = old is None or self.model.modified_field not in old
+
+        if new_last_modified is None or not_specified:
             return new
 
         # Drop the new last_modified if lesser or equal to the old one.
-        new_last_modified = new.get(self.model.modified_field)
         is_greater = new_last_modified <= old[self.model.modified_field]
         if (new_last_modified and is_greater):
             del new[self.model.modified_field]

--- a/cliquet/resource/__init__.py
+++ b/cliquet/resource/__init__.py
@@ -539,7 +539,7 @@ class UserResource(object):
 
         # Drop the new last_modified if lesser or equal to the old one.
         is_greater = new_last_modified <= old[self.model.modified_field]
-        if (new_last_modified and is_greater):
+        if new_last_modified and is_greater:
             del new[self.model.modified_field]
 
         return new

--- a/cliquet/resource/__init__.py
+++ b/cliquet/resource/__init__.py
@@ -492,7 +492,11 @@ class UserResource(object):
         record = self._get_record_or_404(self.record_id)
         self._raise_412_if_modified(record)
 
-        deleted = self.model.delete_record(record)
+        # Retreive the last_modified information from a querystring if present.
+        last_modified = self.request.querystring.get('last_modified')
+
+        deleted = self.model.delete_record(
+            record, last_modified=last_modified)
         return self.postprocess(deleted, action=ACTIONS.DELETE)
 
     #

--- a/cliquet/resource/__init__.py
+++ b/cliquet/resource/__init__.py
@@ -493,7 +493,7 @@ class UserResource(object):
         self._raise_412_if_modified(record)
 
         # Retreive the last_modified information from a querystring if present.
-        last_modified = self.request.querystring.get('last_modified')
+        last_modified = self.request.GET.get('last_modified')
 
         deleted = self.model.delete_record(
             record, last_modified=last_modified)

--- a/cliquet/resource/__init__.py
+++ b/cliquet/resource/__init__.py
@@ -528,6 +528,15 @@ class UserResource(object):
         :returns: the processed record.
         :rtype: dict
         """
+        if old is None or self.model.modified_field not in old:
+            return new
+
+        # Drop the new last_modified if lesser or equal to the old one.
+        new_last_modified = new.get(self.model.modified_field)
+        if (new_last_modified and
+                new_last_modified <= old[self.model.modified_field]):
+            del new[self.model.modified_field]
+
         return new
 
     def apply_changes(self, record, changes):
@@ -1069,6 +1078,7 @@ class ShareableResource(UserResource):
         """Read permissions from request body, and in the case of ``PUT`` every
         existing ACE is removed (using empty list).
         """
+        new = super(ShareableResource, self).process_record(new, old)
         permissions = self.request.validated.get('permissions', {})
 
         annotated = new.copy()

--- a/cliquet/resource/model.py
+++ b/cliquet/resource/model.py
@@ -209,7 +209,7 @@ class Model(object):
                                    modified_field=self.modified_field,
                                    auth=self.auth)
 
-    def delete_record(self, record, parent_id=None):
+    def delete_record(self, record, parent_id=None, last_modified=None):
         """Delete a record in the collection.
 
         Override to perform actions or post-process records after deletion
@@ -237,7 +237,8 @@ class Model(object):
                                    id_field=self.id_field,
                                    modified_field=self.modified_field,
                                    deleted_field=self.deleted_field,
-                                   auth=self.auth)
+                                   auth=self.auth,
+                                   last_modified=last_modified)
 
 
 class ShareableModel(Model):

--- a/cliquet/resource/model.py
+++ b/cliquet/resource/model.py
@@ -324,11 +324,11 @@ class ShareableModel(Model):
         annotated[self.permissions_field] = permissions
         return annotated
 
-    def delete_record(self, record_id, parent_id=None):
+    def delete_record(self, record_id, parent_id=None, last_modified=None):
         """Delete record and its associated permissions.
         """
-        record = super(ShareableModel, self).delete_record(record_id,
-                                                           parent_id)
+        record = super(ShareableModel, self).delete_record(
+            record_id, parent_id, last_modified=last_modified)
         perm_object_id = self.get_permission_object_id(record_id)
         self.permission.delete_object_permissions(perm_object_id)
 

--- a/cliquet/storage/memory.py
+++ b/cliquet/storage/memory.py
@@ -194,14 +194,19 @@ class Storage(MemoryBasedStorage):
             else:
                 current = record[modified_field]
         else:
+            # Otherwise, use a new one.
             current = utils.msec_time()
 
+        # Bump the timestamp only if it's more than the previous one.
         previous = self._timestamps[collection_id].get(parent_id)
         if previous and previous >= current:
             collection_timestamp = previous + 1
         else:
             collection_timestamp = current
 
+        # In case the timestamp was specified, the collection timestamp will
+        # be different from the updated timestamp. As such, we want to return
+        # the one of the record, and not the collection one.
         if not is_specified:
             current = collection_timestamp
 
@@ -256,8 +261,7 @@ class Storage(MemoryBasedStorage):
                deleted_field=DEFAULT_DELETED_FIELD,
                auth=None, last_modified=None):
         existing = self.get(collection_id, parent_id, object_id)
-        # Need to delete the last_modified field of the record for it to not
-        # be kept (in no case we want to keep the old one).
+        # Need to delete the last_modified field of the record.
         del existing[modified_field]
 
         self.set_record_timestamp(collection_id, parent_id, existing,

--- a/cliquet/storage/memory.py
+++ b/cliquet/storage/memory.py
@@ -184,6 +184,7 @@ class Storage(MemoryBasedStorage):
             the time will slide into the future. It is not problematic since
             the timestamp notion is opaque, and behaves like a revision number.
         """
+        # XXX factorize code from memory and redis backends.
         is_specified = (record is not None
                         and modified_field in record
                         or last_modified is not None)

--- a/cliquet/storage/postgresql/__init__.py
+++ b/cliquet/storage/postgresql/__init__.py
@@ -214,14 +214,16 @@ class Storage(StorageBase):
                AND parent_id = :parent_id
                AND collection_id = :collection_id
         )
-        INSERT INTO records (id, parent_id, collection_id, data)
+        INSERT INTO records (id, parent_id, collection_id, data, last_modified)
         VALUES (:object_id, :parent_id,
-                :collection_id, (:data)::JSONB)
+                :collection_id, (:data)::JSONB,
+                from_epoch(:last_modified))
         RETURNING id, as_epoch(last_modified) AS last_modified;
         """
         placeholders = dict(object_id=record_id,
                             parent_id=parent_id,
                             collection_id=collection_id,
+                            last_modified=record.get(modified_field),
                             data=json.dumps(record))
         with self.client.connect() as conn:
             # Check that it does violate the resource unicity rules.
@@ -265,14 +267,16 @@ class Storage(StorageBase):
                modified_field=DEFAULT_MODIFIED_FIELD,
                auth=None):
         query_create = """
-        INSERT INTO records (id, parent_id, collection_id, data)
+        INSERT INTO records (id, parent_id, collection_id, data, last_modified)
         VALUES (:object_id, :parent_id,
-                :collection_id, (:data)::JSONB)
+                :collection_id, (:data)::JSONB,
+                from_epoch(:last_modified))
         RETURNING as_epoch(last_modified) AS last_modified;
         """
 
         query_update = """
-        UPDATE records SET data=(:data)::JSONB
+        UPDATE records SET data=(:data)::JSONB,
+                           last_modified=from_epoch(:last_modified)
         WHERE id = :object_id
            AND parent_id = :parent_id
            AND collection_id = :collection_id
@@ -281,6 +285,7 @@ class Storage(StorageBase):
         placeholders = dict(object_id=object_id,
                             parent_id=parent_id,
                             collection_id=collection_id,
+                            last_modified=record.get(modified_field),
                             data=json.dumps(record))
 
         record = record.copy()
@@ -310,7 +315,7 @@ class Storage(StorageBase):
                id_field=DEFAULT_ID_FIELD, with_deleted=True,
                modified_field=DEFAULT_MODIFIED_FIELD,
                deleted_field=DEFAULT_DELETED_FIELD,
-               auth=None):
+               auth=None, last_modified=None):
         if with_deleted:
             query = """
             WITH deleted_record AS (
@@ -321,8 +326,8 @@ class Storage(StorageBase):
                   AND collection_id = :collection_id
                 RETURNING id
             )
-            INSERT INTO deleted (id, parent_id, collection_id)
-            SELECT id, :parent_id, :collection_id
+            INSERT INTO deleted (id, parent_id, collection_id, last_modified)
+            SELECT id, :parent_id, :collection_id, from_epoch(:last_modified)
               FROM deleted_record
             RETURNING as_epoch(last_modified) AS last_modified;
             """
@@ -337,7 +342,8 @@ class Storage(StorageBase):
             """
         placeholders = dict(object_id=object_id,
                             parent_id=parent_id,
-                            collection_id=collection_id)
+                            collection_id=collection_id,
+                            last_modified=last_modified)
 
         with self.client.connect() as conn:
             result = conn.execute(query, placeholders)

--- a/cliquet/storage/postgresql/migrations/migration_008_009.sql
+++ b/cliquet/storage/postgresql/migrations/migration_008_009.sql
@@ -1,0 +1,41 @@
+CREATE OR REPLACE FUNCTION from_epoch(epoch BIGINT) RETURNS TIMESTAMP AS $$
+BEGIN
+    RETURN TIMESTAMP WITH TIME ZONE 'epoch' + epoch * INTERVAL '1 millisecond';
+END;
+$$ LANGUAGE plpgsql
+IMMUTABLE;
+
+
+CREATE OR REPLACE FUNCTION bump_timestamp()
+RETURNS trigger AS $$
+DECLARE
+    previous TIMESTAMP;
+    current TIMESTAMP;
+
+BEGIN
+    --
+    -- This bumps the current timestamp to 1 msec in the future if the previous
+    -- timestamp is equal to the current one (or higher if was bumped already).
+    --
+    -- If a bunch of requests from the same user on the same collection
+    -- arrive in the same millisecond, the unicity constraint can raise
+    -- an error (operation is cancelled).
+    -- See https://github.com/mozilla-services/cliquet/issues/25
+    --
+    previous := collection_timestamp(NEW.parent_id, NEW.collection_id);
+
+    IF NEW.last_modified IS NULL THEN
+        current := clock_timestamp();
+        IF previous >= current THEN
+            current := previous + INTERVAL '1 milliseconds';
+        END IF;
+        NEW.last_modified := current;
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+
+-- Bump storage schema version.
+INSERT INTO metadata (name, value) VALUES ('storage_schema_version', '9');

--- a/cliquet/storage/redis.py
+++ b/cliquet/storage/redis.py
@@ -89,7 +89,7 @@ class Storage(MemoryBasedStorage):
 
     @wrap_redis_error
     def _bump_timestamp(self, collection_id, parent_id, record=None,
-                        modified_field=None, force_new=False):
+                        modified_field=None, last_modified=None):
 
         key = '{0}.{1}.timestamp'.format(collection_id, parent_id)
         while 1:
@@ -98,15 +98,32 @@ class Storage(MemoryBasedStorage):
                     pipe.watch(key)
                     previous = pipe.get(key)
                     pipe.multi()
-                    if (force_new is False and
-                            record is not None and modified_field in record):
-                        current = record[modified_field]
+                    is_specified = (record is not None
+                                    and modified_field in record
+                                    or last_modified is not None)
+                    if is_specified:
+                        # If there is a timestamp in the new record,
+                        # try to use it.
+                        if last_modified is not None:
+                            current = last_modified
+                        else:
+                            current = record[modified_field]
                     else:
                         current = utils.msec_time()
 
                     if previous and int(previous) >= current:
-                        current = int(previous) + 1
-                    pipe.set(key, current)
+                        collection_timestamp = int(previous) + 1
+                    else:
+                        collection_timestamp = current
+
+                    # Return the newly generated timestamp as the current one
+                    # only if nothing else was specified.
+                    if not is_specified:
+                        current = collection_timestamp
+
+                    print(is_specified, current, collection_timestamp, record)
+
+                    pipe.set(key, collection_timestamp)
                     pipe.execute()
                     return current
                 except redis.WatchError:  # pragma: no cover
@@ -198,7 +215,7 @@ class Storage(MemoryBasedStorage):
                id_field=DEFAULT_ID_FIELD, with_deleted=True,
                modified_field=DEFAULT_MODIFIED_FIELD,
                deleted_field=DEFAULT_DELETED_FIELD,
-               auth=None):
+               auth=None, last_modified=None):
         record_key = '{0}.{1}.{2}.records'.format(collection_id,
                                                   parent_id,
                                                   object_id)
@@ -217,9 +234,13 @@ class Storage(MemoryBasedStorage):
 
         existing = self._decode(encoded_item)
 
+        # Need to delete the last_modified field of the record for it to not
+        # be kept (in no case we want to keep the old one).
+        del existing[modified_field]
+        
         self.set_record_timestamp(collection_id, parent_id, existing,
                                   modified_field=modified_field,
-                                  force_new=True)
+                                  last_modified=last_modified)
         existing = self.strip_deleted_record(collection_id, parent_id,
                                              existing)
 

--- a/cliquet/storage/redis.py
+++ b/cliquet/storage/redis.py
@@ -121,8 +121,6 @@ class Storage(MemoryBasedStorage):
                     if not is_specified:
                         current = collection_timestamp
 
-                    print(is_specified, current, collection_timestamp, record)
-
                     pipe.set(key, collection_timestamp)
                     pipe.execute()
                     return current
@@ -234,10 +232,9 @@ class Storage(MemoryBasedStorage):
 
         existing = self._decode(encoded_item)
 
-        # Need to delete the last_modified field of the record for it to not
-        # be kept (in no case we want to keep the old one).
+        # Need to delete the last_modified field.
         del existing[modified_field]
-        
+
         self.set_record_timestamp(collection_id, parent_id, existing,
                                   modified_field=modified_field,
                                   last_modified=last_modified)

--- a/cliquet/storage/redis.py
+++ b/cliquet/storage/redis.py
@@ -98,6 +98,7 @@ class Storage(MemoryBasedStorage):
                     pipe.watch(key)
                     previous = pipe.get(key)
                     pipe.multi()
+                    # XXX factorize code from memory and redis backends.
                     is_specified = (record is not None
                                     and modified_field in record
                                     or last_modified is not None)

--- a/cliquet/tests/resource/test_record.py
+++ b/cliquet/tests/resource/test_record.py
@@ -142,6 +142,23 @@ class DeleteTest(BaseTest):
         self.assertNotIn('field', result)
         self.assertIn('last_modified', result)
 
+    def test_delete_uses_last_modified_from_querystring(self):
+        record = self.model.create_record({'field': 'value'})
+        last_modified = record[self.model.modified_field] + 20
+        self.resource.record_id = record['id']
+        self.resource.request.GET = {
+            'last_modified': last_modified
+        }
+
+        result = self.resource.delete()['data']
+        self.assertEqual(result[self.model.modified_field], last_modified)
+
+        self.resource.request.GET = {'_since': '0', 'deleted': 'true'}
+        result = self.resource.collection_get()
+        self.assertEqual(len(result['data']), 1)
+        retrieved = result['data'][0]
+        self.assertEqual(retrieved[self.model.modified_field], last_modified)
+
 
 class PatchTest(BaseTest):
     def setUp(self):

--- a/cliquet/tests/resource/test_record.py
+++ b/cliquet/tests/resource/test_record.py
@@ -81,6 +81,34 @@ class PutTest(BaseTest):
                             result['last_modified'])
         self.assertNotEqual(self.record['field'], 'new')
 
+    def test_last_modified_is_kept_if_present(self):
+        new_last_modified = self.record['last_modified'] + 20
+        self.resource.request.validated = {'data': {
+            'field': 'new',
+            'last_modified': new_last_modified}
+        }
+        result = self.resource.put()['data']
+        self.assertEqual(result['last_modified'], new_last_modified)
+
+    def test_last_modified_is_dropped_if_same_as_previous(self):
+        self.resource.request.validated = {'data': {
+            'field': 'new',
+            'last_modified': self.record['last_modified']}
+        }
+        result = self.resource.put()['data']
+        self.assertGreater(result['last_modified'],
+                           self.record['last_modified'])
+
+    def test_last_modified_is_dropped_if_lesser_than_existing(self):
+        new_last_modified = self.record['last_modified'] - 20
+        self.resource.request.validated = {'data': {
+            'field': 'new',
+            'last_modified': new_last_modified}
+        }
+        result = self.resource.put()['data']
+        self.assertNotEqual(result['last_modified'],
+                            self.record['last_modified'])
+
     def test_cannot_replace_with_different_id(self):
         self.resource.request.validated = {'data': {'id': 'abc'}}
         self.assertRaises(httpexceptions.HTTPBadRequest, self.resource.put)

--- a/cliquet/tests/test_storage.py
+++ b/cliquet/tests/test_storage.py
@@ -265,9 +265,8 @@ class BaseTestStorage(object):
         self.assertEquals(retrieved[self.modified_field], last_modified)
 
         # collection timestamp should not be modified.
-        collection_timestamp = self.storage.collection_timestamp(
-            **self.storage_kw)
-        self.assertEquals(collection_timestamp, last_modified)
+        collection_ts = self.storage.collection_timestamp(**self.storage_kw)
+        self.assertEquals(collection_ts, last_modified)
 
     def test_create_does_generate_a_new_last_modified_field(self):
         record = self.record.copy()

--- a/cliquet/tests/test_storage.py
+++ b/cliquet/tests/test_storage.py
@@ -253,6 +253,22 @@ class BaseTestStorage(object):
                           self.create_record,
                           record=record)
 
+    def test_create_preserves_the_passed_last_modified_when_provided(self):
+        last_modified = 1448881675541
+        record = self.record.copy()
+        record[self.id_field] = RECORD_ID
+        record[self.modified_field] = last_modified
+        self.create_record(record=record)
+
+        retrieved = self.storage.get(object_id=RECORD_ID, **self.storage_kw)
+        self.assertIn(self.modified_field, retrieved)
+        self.assertEquals(retrieved[self.modified_field], last_modified)
+
+        # collection timestamp should not be modified.
+        collection_timestamp = self.storage.collection_timestamp(
+            **self.storage_kw)
+        self.assertEquals(collection_timestamp, last_modified)
+
     def test_create_does_generate_a_new_last_modified_field(self):
         record = self.record.copy()
         self.assertNotIn(self.modified_field, record)

--- a/cliquet/tests/test_storage.py
+++ b/cliquet/tests/test_storage.py
@@ -345,6 +345,19 @@ class BaseTestStorage(object):
             **self.storage_kw
         )
 
+    def test_delete_can_specify_the_last_modified(self):
+        stored = self.create_record()
+        last_modified = stored[self.modified_field] + 10
+        self.storage.delete(
+            object_id=stored['id'],
+            last_modified=last_modified,
+            **self.storage_kw)
+
+        records, count = self.storage.get_all(
+            include_deleted=True, **self.storage_kw)
+
+        self.assertEquals(records[0][self.modified_field], last_modified)
+
     def test_delete_raise_when_unknown(self):
         self.assertRaises(
             exceptions.RecordNotFoundError,

--- a/cliquet/tests/test_storage.py
+++ b/cliquet/tests/test_storage.py
@@ -1172,12 +1172,13 @@ class PostgreSQLStorageTest(StorageTest, unittest.TestCase):
 
     def test_update_preserves_record_timestamp_if_less_than_collection(self):
         first_record = self.create_record()
+        t0 = first_record[self.modified_field]
         second_record = self.create_record()
 
-        # Update the second record to have a last_modified of t0-10
+        # Update the second record to have a last_modified of t0-100
         record_id = second_record[self.id_field]
         record = self.record.copy()
-        record[self.modified_field] = second_record[self.modified_field] - 10
+        record[self.modified_field] = second_record[self.modified_field] - 100
         self.storage.update(object_id=record_id, record=record,
                             **self.storage_kw)
 
@@ -1187,9 +1188,7 @@ class PostgreSQLStorageTest(StorageTest, unittest.TestCase):
         self.assertEquals(retrieved[self.modified_field],
                           record[self.modified_field])
 
-        # The collection timestamp should be bumped in this case.
+        # The collection timestamp should equal to the max last_modified (t0).
         collection_timestamp = self.storage.collection_timestamp(
             **self.storage_kw)
-        self.assertEquals(
-            collection_timestamp,
-            first_record[self.modified_field])
+        self.assertEquals(collection_timestamp, t0)

--- a/cliquet_docs/api/resource.rst
+++ b/cliquet_docs/api/resource.rst
@@ -500,10 +500,17 @@ The consumer might decide to ignore it.
 If the request header ``If-Match`` is provided, and if the record has
 changed meanwhile, a ``412 Precondition failed`` error is returned.
 
+The timestamp value of the deleted record can be enforced via the
+``last_modified`` QueryString parameter.
+
 .. note::
 
     Once deleted, a record will appear in the collection when polling for changes,
     with a deleted status (``delete=true``) and will have most of its fields empty.
+
+.. versionadded:: 2.13::
+
+  Enforcement of the timestamp value for records has been added.
 
 HTTP Status Code
 ----------------
@@ -534,6 +541,9 @@ Validation and conflicts behaviour is similar to creating records (``POST``).
 If the request header ``If-Match`` is provided, and if the record has
 changed meanwhile, a ``412 Precondition failed`` error is returned.
 
+.. versionadded:: 2.13::
+
+  Enforcement of the timestamp value for records has been added.
 
 **Request**:
 
@@ -701,7 +711,7 @@ be able to issue requests successfully.
 
 Shareable resources allow permissions management via ``permissions`` attribute
 in the JSON payloads, along the ``data`` attributes. Permissions can also be
-replaced and modified independantly from data.
+replaced and modified independently from data.
 
 On a request, ``permissions`` is a json dict containing the permissions for
 the record to be modified. It has the following signature::

--- a/cliquet_docs/reference/resource.rst
+++ b/cliquet_docs/reference/resource.rst
@@ -35,6 +35,7 @@ Full example
         mapping = BookmarkSchema()
 
         def process_record(self, new, old=None):
+            new = super(Bookmark, self).process_record(new, old)
             if new['device'] != old['device']:
                 new['device'] = self.request.headers.get('User-Agent')
 


### PR DESCRIPTION
Allow to keep the `last_modified` header when specified in the data.  Fixes #587.
