### PR TITLE
Fixes duplicated records in paginated results when limit is forced via settings (fixes #588)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,10 @@ This document describes changes between each past release.
 2.12.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+**Bug fixes**
+
+- Fixes duplicated records in paginated results when limit is forced via
+  settings (fixes #588)
 
 
 2.12.0 (2015-11-27)

--- a/cliquet/resource/__init__.py
+++ b/cliquet/resource/__init__.py
@@ -217,8 +217,8 @@ class UserResource(object):
 
         headers = self.request.response.headers
         filters = self._extract_filters()
-        sorting = self._extract_sorting()
         limit = self._extract_limit()
+        sorting = self._extract_sorting(limit)
         filter_fields = [f.field for f in filters]
         include_deleted = self.model.modified_field in filter_fields
 
@@ -896,10 +896,9 @@ class UserResource(object):
 
         return filters
 
-    def _extract_sorting(self):
+    def _extract_sorting(self, limit):
         """Extracts filters from QueryString parameters."""
         specified = self.request.GET.get('_sort', '').split(',')
-        limit = '_limit' in self.request.GET
         sorting = []
         modified_field_used = self.model.modified_field in specified
         for field in specified:

--- a/cliquet/tests/resource/test_pagination.py
+++ b/cliquet/tests/resource/test_pagination.py
@@ -67,7 +67,7 @@ class PaginationTest(BaseTest):
         self.assertIn('_limit', queryparams)
         self.assertIn('_token', queryparams)
 
-    def test_next_page_url_gives_next_page(self):
+    def test_next_page_url_gives_distinct_records(self):
         self.resource.request.GET = {'_limit': '10'}
         results1 = self.resource.collection_get()
         self._setup_next_page()
@@ -75,6 +75,17 @@ class PaginationTest(BaseTest):
         results_id1 = set([x['id'] for x in results1['data']])
         results_id2 = set([x['id'] for x in results2['data']])
         self.assertFalse(results_id1.intersection(results_id2))
+
+    def test_next_page_url_gives_distinct_records_with_forced_limit(self):
+        with mock.patch.dict(self.resource.request.registry.settings, [
+                ('paginate_by', 5)]):
+            results1 = self.resource.collection_get()
+            self._setup_next_page()
+            results2 = self.resource.collection_get()
+
+            results_id1 = set([x['id'] for x in results1['data']])
+            results_id2 = set([x['id'] for x in results2['data']])
+            self.assertFalse(results_id1.intersection(results_id2))
 
     def test_twice_the_same_next_page(self):
         self.resource.request.GET = {'_limit': '10'}


### PR DESCRIPTION
@almet r?