### PR TITLE
API Capabilities

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,9 @@ This document describes changes between each past release.
 **Protocol**
 
 - Forward slashes (``/``) are not escaped anymore in JSON responses (ref #537)
+- The API capabilities can be exposed in a ``capabilities`` attribute in the
+  root URL (#628). Clients can rely on this to detect optional features on the
+  server (e.g. enabled plugins).
 
 
 2.14.0 (2016-01-15)

--- a/cliquet/__init__.py
+++ b/cliquet/__init__.py
@@ -119,9 +119,10 @@ def includeme(config):
 
     # Directive to declare arbitrary API capabilities.
     def add_api_capability(config, identifier, description="", url="", **kw):
-        if identifier in config.registry.api_capabilities:
-            error_msg = "API capability '%s' already exists." % identifier
-            raise ValueError(error_msg)
+        existing = config.registry.api_capabilities.get(identifier)
+        if existing:
+            error_msg = "The '%s' API capability was already registered (%s)."
+            raise ValueError(error_msg % (identifier, existing))
 
         capability = dict(description=description, url=url, **kw)
         config.registry.api_capabilities[identifier] = capability

--- a/cliquet/__init__.py
+++ b/cliquet/__init__.py
@@ -117,6 +117,18 @@ def includeme(config):
     # Public settings registry.
     config.registry.public_settings = {'batch_max_requests', 'readonly'}
 
+    # Directive to declare arbitrary API capabilities.
+    def add_api_capability(config, identifier, description="", url="", **kw):
+        if identifier in config.registry.api_capabilities:
+            error_msg = "API capability '%s' already exists." % identifier
+            raise ValueError(error_msg)
+
+        capability = dict(description=description, url=url, **kw)
+        config.registry.api_capabilities[identifier] = capability
+
+    config.add_directive('add_api_capability', add_api_capability)
+    config.registry.api_capabilities = {}
+
     # Setup cornice.
     config.include("cornice")
 

--- a/cliquet/tests/support.py
+++ b/cliquet/tests/support.py
@@ -88,8 +88,9 @@ class BaseWebTest(object):
             'Authorization': 'Basic bWF0OjE='
         }
 
-    def make_app(self, settings=None):
-        app = webtest.TestApp(testapp(self.get_app_settings(settings)))
+    def make_app(self, settings=None, config=None):
+        wsgi_app = testapp(self.get_app_settings(settings), config=config)
+        app = webtest.TestApp(wsgi_app)
         app.RequestClass = get_request_class(self.api_prefix)
         return app
 

--- a/cliquet/views/hello.py
+++ b/cliquet/views/hello.py
@@ -43,6 +43,9 @@ def get_hello(request):
     if prefixed_userid:
         data['user'] = request.get_user_info()
 
+    # Application can register and expose arbitrary capabilities.
+    data['capabilities'] = request.registry.api_capabilities
+
     return data
 
 

--- a/cliquet_docs/api/utilities.rst
+++ b/cliquet_docs/api/utilities.rst
@@ -25,7 +25,16 @@ The returned value is a JSON mapping containing:
 
 - ``capabilities``: a mapping used by clients to detect optional features of the API.
 
-  - Example: ``{"auth-fxa": {"description": "Firefox Account authentication", "url": "http://github.com/mozilla-services/cliquet-fxa"}}``
+  - Example:
+
+    .. code-block:: javascript
+
+        {
+          "auth-fxa": {
+            "description": "Firefox Account authentication",
+            "url": "http://github.com/mozilla-services/cliquet-fxa"
+          }
+        }
 
 **Optional**
 

--- a/cliquet_docs/api/utilities.rst
+++ b/cliquet_docs/api/utilities.rst
@@ -23,6 +23,10 @@ The returned value is a JSON mapping containing:
   - ``batch_max_requests``: Number of requests that can be made in a batch request.
   - ``readonly``: Only requests with read operations are allowed.
 
+- ``capabilities``: a mapping used by clients to detect optional features of the API.
+
+  - Example: ``{"auth-fxa": {"description": "Firefox Account authentication", "url": "http://github.com/mozilla-services/cliquet-fxa"}}``
+
 **Optional**
 
 - ``user``: A mapping with an ``id`` field for the currently connected user id.

--- a/cliquet_docs/ecosystem.rst
+++ b/cliquet_docs/ecosystem.rst
@@ -125,6 +125,39 @@ In this example, if the environment variable ``CLIQUET_ELASTICSEARCH_REFRESH_ENA
 is set to ``true``, the value present in configuration file is ignored.
 
 
+
+Declare API capabilities
+========================
+
+Arbitrary capabilities can be declared and exposed in the :ref:`root URL <api-utilities>`.
+
+Clients can rely on this to detect optional features on the server. For example,
+features brought by plugins.
+
+
+.. code-block:: python
+    :emphasize-lines: 7-11
+
+    def main(global_config, **settings):
+        config = Configurator(settings=settings)
+
+        cliquet.initialize(config, __version__)
+        config.scan("myproject.views")
+
+        settings = config.get_settings()
+        if settings['flush_enabled']:
+            config.add_api_capability("flush",
+                                      description="Flush server using endpoint",
+                                      url="http://kinto.readthedocs.org/en/latest/configuration/settings.html#activating-the-flush-endpoint")
+
+        return config.make_wsgi_app()
+
+.. note::
+
+    Any argument passed to ``config.add_api_capability()`` will be exposed in the
+    root URL.
+
+
 Custom backend
 ==============
 

--- a/cliquet_docs/quickstart.rst
+++ b/cliquet_docs/quickstart.rst
@@ -200,33 +200,6 @@ Advanced initialization
 .. autofunction:: cliquet.initialize
 
 
-
-Declare API capabilities
-------------------------
-
-Arbitrary capabilities can be declared and exposed in the :ref:`root URL <api-utilities>`.
-
-Clients can rely on this to detect optional features on the server (e.g. enabled plugins).
-
-.. code-block:: python
-    :emphasize-lines: 7-11
-
-    def main(global_config, **settings):
-        config = Configurator(settings=settings)
-
-        cliquet.initialize(config, __version__)
-        config.scan("myproject.views")
-
-        settings = config.get_settings()
-        if settings['flush_enabled']:
-            config.add_api_capability("flush",
-                                      description="Flush server using endpoint",
-                                      url="http://kinto.readthedocs.org/en/latest/configuration/settings.html#activating-the-flush-endpoint")
-
-        return config.make_wsgi_app()
-
-
-
 Beyond Cliquet
 --------------
 

--- a/cliquet_docs/quickstart.rst
+++ b/cliquet_docs/quickstart.rst
@@ -200,6 +200,33 @@ Advanced initialization
 .. autofunction:: cliquet.initialize
 
 
+
+Declare API capabilities
+------------------------
+
+Arbitrary capabilities can be declared and exposed in the :ref:`root URL <api-utilities>`.
+
+Clients can rely on this to detect optional features on the server (e.g. enabled plugins).
+
+.. code-block:: python
+    :emphasize-lines: 7-11
+
+    def main(global_config, **settings):
+        config = Configurator(settings=settings)
+
+        cliquet.initialize(config, __version__)
+        config.scan("myproject.views")
+
+        settings = config.get_settings()
+        if settings['flush_enabled']:
+            config.add_api_capability("flush",
+                                      description="Flush server using endpoint",
+                                      url="http://kinto.readthedocs.org/en/latest/configuration/settings.html#activating-the-flush-endpoint")
+
+        return config.make_wsgi_app()
+
+
+
 Beyond Cliquet
 --------------
 


### PR DESCRIPTION
I suggest we expose something like this on the Python side for plugins:

```python
config.add_api_capability("identifier", description="", documentation="")
```
> It would raise an error if already defined for example


And shown in the root URL as a mapping:

```js
"capabilities": {
  "auth-fxa": {
    "description": "Firefox Account authentication",
    "documentation": "http://github.com/mozilla-services/cliquet-fxa"
  }
}
```

@almet @n1k0 @Natim thoughts? 