### PR TITLE
Allow custom views to handle errors in batch (fixes mozilla-services/syncto#78, rel #629)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,10 @@ This document describes changes between each past release.
 
 - Forward slashes (``/``) are not escaped anymore in JSON responses (ref #537)
 
+**Bug fixes**
+
+- Batch now relies on custom views responses (``@viewconfig(context=Error)``)
+  (fixes mozilla-services/syncto#78, rel #629)
 
 2.14.0 (2016-01-15)
 -------------------

--- a/cliquet/tests/test_views_batch.py
+++ b/cliquet/tests/test_views_batch.py
@@ -73,6 +73,20 @@ class BatchViewTest(BaseWebTest, unittest.TestCase):
             self.app.post_json('/batch', body, headers=self.headers,
                                status=500)
 
+    def test_errors_handled_by_view_does_not_make_the_batch_fail(self):
+        from requests.exceptions import HTTPError
+
+        request = {'path': '/v0/'}
+        body = {'requests': [request]}
+
+        with mock.patch('cliquet.views.hello.get_eos') as mocked:
+            response = mock.MagicMock(status_code=404)
+            mocked.side_effect = HTTPError(response=response)
+            resp = self.app.post_json('/batch', body, headers=self.headers,
+                                      status=200)
+            subresponse = resp.json['responses'][0]['body']
+            self.assertEqual(subresponse, 'Handled in tests/testapp/views.py')
+
     def test_batch_cannot_be_recursive(self):
         requests = {'requests': [{'path': '/v0/'}]}
         request = {'method': 'POST', 'path': '/v0/batch', 'body': requests}

--- a/cliquet/tests/test_views_transaction.py
+++ b/cliquet/tests/test_views_transaction.py
@@ -84,6 +84,21 @@ class TransactionTest(PostgreSQLTest, unittest.TestCase):
         resp = self.app.get('/mushrooms', headers=self.headers)
         self.assertEqual(len(resp.json['data']), 0)
 
+    def test_modifications_are_not_rolled_back_on_4XX_error(self):
+        request_create = {
+            'method': 'POST',
+            'path': '/mushrooms',
+            'body': {'data': {'name': 'Vesse de loup'}}
+        }
+        request_get = {
+            'method': 'GET',
+            'path': '/this-is-an-unknown-url',
+        }
+        body = {'requests': [request_create, request_get]}
+        resp = self.app.post_json('/batch', body, headers=self.headers)
+        resp = self.app.get('/mushrooms', headers=self.headers)
+        self.assertEqual(len(resp.json['data']), 1)
+
     def test_modifications_are_rolled_back_on_error_accross_backends(self):
         self.run_failing_post()
 

--- a/cliquet/tests/testapp/views.py
+++ b/cliquet/tests/testapp/views.py
@@ -1,3 +1,8 @@
+from pyramid import httpexceptions
+from pyramid.view import view_config
+from pyramid.security import NO_PERMISSION_REQUIRED
+from requests.exceptions import HTTPError
+
 from cliquet import resource
 import colander
 
@@ -42,3 +47,11 @@ class SchemaLess(resource.ResourceSchema):
 @resource.register()
 class Spore(resource.ShareableResource):
     mapping = SchemaLess()
+
+
+@view_config(context=HTTPError, permission=NO_PERMISSION_REQUIRED)
+def response_error(context, request):
+    if context.response.status_code == 404:
+        error_msg = "Handled in tests/testapp/views.py"
+        return httpexceptions.HTTPNotFound(body=error_msg)
+    raise context

--- a/cliquet/views/batch.py
+++ b/cliquet/views/batch.py
@@ -1,8 +1,9 @@
 import colander
 import six
 
-from pyramid.security import NO_PERMISSION_REQUIRED
 from pyramid import httpexceptions
+from pyramid.security import NO_PERMISSION_REQUIRED
+from pyramid.view import render_view_to_response
 
 from cliquet import errors
 from cliquet import logger
@@ -104,6 +105,10 @@ def post_batch(request):
             else:
                 # JSONify raw Pyramid errors.
                 resp = errors.http_error(e)
+        except Exception as e:
+            resp = render_view_to_response(e, subrequest)
+            if resp.status_code >= 500:
+                raise e
 
         sublogger.bind(code=resp.status_code)
         sublogger.info('subrequest.summary')


### PR DESCRIPTION
This is my proposition for the syncto fix. 

It does not change current protocol or transaction behaviour (decision for #629 can be made later)

@Natim r?