### PR TITLE
Fix distinction and optimize (un)authenticated_userid

### DIFF
--- a/cliquet/__init__.py
+++ b/cliquet/__init__.py
@@ -5,6 +5,7 @@ import pkg_resources
 from cornice import Service as CorniceService
 from pyramid.settings import aslist
 
+from cliquet import authentication
 from cliquet import errors
 from cliquet import events
 from cliquet.initialization import (  # NOQA
@@ -78,6 +79,7 @@ DEFAULT_SETTINGS = {
     'storage_url': '',
     'storage_max_fetch_size': 10000,
     'storage_pool_size': 25,
+    'tm.annotate_user': False,  # Do annotate transactions with the user-id.
     'transaction_per_request': True,
     'userid_hmac_secret': '',
     'version_prefix_redirect_enabled': True,
@@ -155,7 +157,8 @@ def includeme(config):
 
     # Custom helpers.
     config.add_request_method(follow_subrequest)
-    config.add_request_method(lambda request: {'id': request.prefixed_userid},
+    config.add_request_method(authentication.prefixed_userid, property=True)
+    config.add_request_method(lambda r: {'id': r.prefixed_userid},
                               name='get_user_info')
     config.add_request_method(current_resource_name, reify=True)
     config.add_request_method(current_service, reify=True)

--- a/cliquet/authentication.py
+++ b/cliquet/authentication.py
@@ -11,7 +11,7 @@ def prefixed_userid(request):
     """
     # If pyramid_multiauth is used, a ``authn_type`` is set on request
     # when a policy succesfully authenticates a user.
-    # (see :func:`cliquet.initializatio.setup_authentication`)
+    # (see :func:`cliquet.initialization.setup_authentication`)
     authn_type = getattr(request, 'authn_type', None)
     if authn_type is not None:
         return authn_type + ':' + request.selected_userid
@@ -32,10 +32,9 @@ class BasicAuthAuthenticationPolicy(base_auth.BasicAuthAuthenticationPolicy):
                                                             **kwargs)
 
     def effective_principals(self, request):
-        """Bypass default Pyramid construction of principals because
-        Pyramid multiauth already adds userid, Authenticated and Everyone
-        principals.
-        """
+        # Bypass default Pyramid construction of principals because
+        # Pyramid multiauth already adds userid, Authenticated and Everyone
+        # principals.
         return []
 
     def unauthenticated_userid(self, request):

--- a/cliquet/authentication.py
+++ b/cliquet/authentication.py
@@ -3,6 +3,20 @@ from pyramid import authentication as base_auth
 from cliquet import utils
 
 
+def prefixed_userid(request):
+    """In Cliquet users ids are prefixed with the policy name that is
+    contained in Pyramid Multiauth.
+    If a custom authn policy is used, without authn_type, this method returns
+    the user id without prefix.
+    """
+    # If pyramid_multiauth is used, a ``authn_type`` is set on request
+    # when a policy succesfully authenticates a user.
+    # (see :func:`cliquet.initializatio.setup_authentication`)
+    authn_type = getattr(request, 'authn_type', None)
+    if authn_type is not None:
+        return authn_type + ':' + request.selected_userid
+
+
 class BasicAuthAuthenticationPolicy(base_auth.BasicAuthAuthenticationPolicy):
     """Basic auth implementation.
 
@@ -16,6 +30,13 @@ class BasicAuthAuthenticationPolicy(base_auth.BasicAuthAuthenticationPolicy):
         super(BasicAuthAuthenticationPolicy, self).__init__(noop_check,
                                                             *args,
                                                             **kwargs)
+
+    def effective_principals(self, request):
+        """Bypass default Pyramid construction of principals because
+        Pyramid multiauth already adds userid, Authenticated and Everyone
+        principals.
+        """
+        return []
 
     def unauthenticated_userid(self, request):
         settings = request.registry.settings

--- a/cliquet/authorization.py
+++ b/cliquet/authorization.py
@@ -25,6 +25,7 @@ def groupfinder(userid, request):
     if not backend:
         return []
 
+    # Safety check when Cliquet is used without pyramid_multiauth.
     if request.prefixed_userid:
         userid = request.prefixed_userid
 

--- a/cliquet/authorization.py
+++ b/cliquet/authorization.py
@@ -1,10 +1,12 @@
 import functools
+
 from pyramid.settings import aslist
 from pyramid.security import IAuthorizationPolicy, Authenticated
 from zope.interface import implementer
 
 from cliquet import utils
 from cliquet.storage import exceptions as storage_exceptions
+from cliquet.authentication import prefixed_userid
 
 # A permission is called "dynamic" when it's computed at request time.
 DYNAMIC = 'dynamic'
@@ -23,15 +25,13 @@ def groupfinder(userid, request):
     if not backend:
         return []
 
-    # Anonymous safety check.
-    if not hasattr(request, 'prefixed_userid'):
-        return []
+    if request.prefixed_userid:
+        userid = request.prefixed_userid
 
     # Query the permission backend only once per request (e.g. batch).
-
-    reify_key = request.prefixed_userid + '_principals'
+    reify_key = userid + '_principals'
     if reify_key not in request.bound_data:
-        principals = backend.user_principals(request.prefixed_userid)
+        principals = backend.user_principals(userid)
         request.bound_data[reify_key] = principals
 
     return request.bound_data[reify_key]
@@ -48,9 +48,10 @@ class AuthorizationPolicy(object):
             return Authenticated in principals
 
         # Add prefixed user id to principals.
-        if context.prefixed_userid:
-            principals = principals + [context.prefixed_userid]
-            prefix, user_id = context.prefixed_userid.split(':', 1)
+        prefixed_userid = context.get_prefixed_userid()
+        if prefixed_userid and ':' in prefixed_userid:
+            principals = principals + [prefixed_userid]
+            prefix, user_id = prefixed_userid.split(':', 1)
             # Remove unprefixed user id to avoid conflicts.
             # (it is added via Pyramid Authn policy effective principals)
             if user_id in principals:
@@ -110,7 +111,7 @@ class RouteFactory(object):
 
     def __init__(self, request):
         # Make it available for the authorization policy.
-        self.prefixed_userid = getattr(request, "prefixed_userid", None)
+        self.get_prefixed_userid = functools.partial(prefixed_userid, request)
 
         self._check_permission = request.registry.permission.check_permission
 

--- a/cliquet/resource/__init__.py
+++ b/cliquet/resource/__init__.py
@@ -177,7 +177,7 @@ class UserResource(object):
         :rtype: str
 
         """
-        return getattr(request, 'prefixed_userid', None)
+        return request.prefixed_userid
 
     def _get_known_fields(self):
         """Return all the `field` defined in the ressource mapping."""

--- a/cliquet/tests/support.py
+++ b/cliquet/tests/support.py
@@ -170,7 +170,7 @@ class AllowAuthorizationPolicy(object):
         if Everyone in principals:
             return True
         # Cliquet default authz policy uses prefixed_userid.
-        prefixed = [getattr(context, 'prefixed_userid', None)]
+        prefixed = [context.prefixed_userid]
         return USER_PRINCIPAL in (principals + prefixed)
 
     def principals_allowed_by_permission(self, context, permission):

--- a/cliquet/tests/test_authentication.py
+++ b/cliquet/tests/test_authentication.py
@@ -1,4 +1,5 @@
 import mock
+import uuid
 
 from cliquet import authentication
 from cliquet import utils
@@ -61,6 +62,16 @@ class AuthenticationPoliciesTest(BaseWebTest, unittest.TestCase):
         }
         self.app.post_json('/batch', batch)
         self.assertEqual(mocked.call_count, 3)
+
+    def test_basicauth_hash_is_computed_only_once(self):
+        # hmac_digest() is used in Basic Authentication only.
+        patch = mock.patch('cliquet.utils.hmac_digest')
+        self.addCleanup(patch.stop)
+        mocked = patch.start()
+        body = {"data": {"name": "haha"}}
+        record_url = self.get_item_url(uuid.uuid4())
+        self.app.put_json(record_url, body, headers=self.headers)
+        self.assertEqual(mocked.call_count, 1)
 
 
 class BasicAuthenticationPolicyTest(unittest.TestCase):

--- a/cliquet/tests/test_initialization.py
+++ b/cliquet/tests/test_initialization.py
@@ -338,15 +338,15 @@ class StatsDConfigurationTest(unittest.TestCase):
         cliquet.initialize(self.config, '0.0.1', 'project_name')
         app = webtest.TestApp(self.config.make_wsgi_app())
         headers = {'Authorization': 'Basic bWF0Og=='}
-        app.get('/v0/__heartbeat__', headers=headers)
-        mocked().count.assert_any_call('users', unique='mat')
+        app.get('/v0/', headers=headers)
+        mocked().count.assert_any_call('users', unique='basicauth:mat')
 
     @mock.patch('cliquet.statsd.Client')
     def test_statsd_counts_authentication_types(self, mocked):
         cliquet.initialize(self.config, '0.0.1', 'project_name')
         app = webtest.TestApp(self.config.make_wsgi_app())
         headers = {'Authorization': 'Basic bWF0Og=='}
-        app.get('/v0/__heartbeat__', headers=headers)
+        app.get('/v0/', headers=headers)
         mocked().count.assert_any_call('authn_type.basicauth')
 
 

--- a/cliquet/tests/test_views_hello.py
+++ b/cliquet/tests/test_views_hello.py
@@ -61,7 +61,7 @@ class HelloViewTest(BaseWebTest, unittest.TestCase):
         response = self.app.get('/', headers=self.headers)
         userid = response.json['user']['id']
         self.assertTrue(userid.startswith('basicauth:'),
-                        '"%s" does not starts with "basicauth:"' % userid)
+                        '"%s" does not start with "basicauth:"' % userid)
 
     def test_return_http_api_version_when_set(self):
         with mock.patch.dict(

--- a/cliquet/views/errors.py
+++ b/cliquet/views/errors.py
@@ -1,7 +1,7 @@
 from functools import wraps
 
 from pyramid import httpexceptions
-from pyramid.security import forget, NO_PERMISSION_REQUIRED
+from pyramid.security import forget, NO_PERMISSION_REQUIRED, Authenticated
 from pyramid.view import (
     forbidden_view_config, notfound_view_config, view_config
 )
@@ -32,7 +32,7 @@ def authorization_required(request):
     """Distinguish authentication required (``401 Unauthorized``) from
     not allowed (``403 Forbidden``).
     """
-    if not request.authenticated_userid:
+    if Authenticated not in request.effective_principals:
         error_msg = "Please authenticate yourself to use this endpoint."
         response = http_error(httpexceptions.HTTPUnauthorized(),
                               errno=ERRORS.MISSING_AUTH_TOKEN,

--- a/cliquet/views/hello.py
+++ b/cliquet/views/hello.py
@@ -1,4 +1,4 @@
-from pyramid.security import NO_PERMISSION_REQUIRED
+from pyramid.security import NO_PERMISSION_REQUIRED, Authenticated
 
 from cliquet import Service, PROTOCOL_VERSION
 
@@ -39,8 +39,9 @@ def get_hello(request):
             value = settings[setting]
         data['settings'][setting] = value
 
-    prefixed_userid = getattr(request, 'prefixed_userid', None)
-    if prefixed_userid:
+    # If current user is authenticated, add user info:
+    # (Note: this will call authenticated_userid() with multiauth+groupfinder)
+    if Authenticated in request.effective_principals:
         data['user'] = request.get_user_info()
 
     # Application can register and expose arbitrary capabilities.

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ REQUIREMENTS = [
     'colander',
     'cornice >= 1.1',  # Fix cache CORS
     'python-dateutil',
-    'pyramid_multiauth >= 0.7',  # Contained policy names.
+    'pyramid_multiauth >= 0.8',  # User on policy selected event.
     'pyramid_tm',
     'redis',  # Default backend
     'requests',


### PR DESCRIPTION
* [x] Disable `pyramid_tm` annotation of the transaction with unnecessary user info.
* [x] Fix distinction between unauthenticated_userid (cached) and authenticated_userid (verified) (?)
* [x] Make sure we don't compute user id hash several times per request
* [x] Requires https://github.com/mozilla-services/pyramid_multiauth/pull/14 to be merged and released

pair=@almet