### PR TITLE
Distinguish before/after events

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -39,14 +39,14 @@ This document describes changes between each past release.
 - Add method to remove a principal from every user
 - Validate that the client can accept JSON response. (#667)
 - Validate that the client can only send JSON request body. (#667)
-- Added new ``AfterResourceChanged`` event, that is sent only when the commit
-  in database is successful.
+- Added a new ``AfterResourceChanged`` event, that is sent only when the commit
+  in database is done and successful.
 
   Subscribers of this event can fail, errors are swallowed and logged. The
-  final transaction result cannot be altered.
+  final transaction result (or response) cannot be altered.
 
-  Since commit occured and operations will not be rolledback, subcribers running
-  irreversible actions should subscribe to this event
+  Since commit occured successfully and operations will not be rolledback,
+  subcribers running irreversible actions should subscribe to this event
   (like sending messages, deleting files, or run asynchronous tasks).
 
 **Bug fixes**

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,8 +9,8 @@ This document describes changes between each past release.
 
 **Breaking changes**
 
-- Errors are not swallowed during execution of ``ResourceChanged`` subscribers
-  anymore.
+- Errors are not swallowed anymore during the execution of ``ResourceChanged``
+  events subscribers.
 
   Subscribers are still executed within the transaction like before.
 
@@ -18,7 +18,7 @@ This document describes changes between each past release.
   Every subscriber execution succeeds, or none.
 
   Thus, subscribers of these events should only perform operations that are reversed
-  on transaction rollback (e.g. database storage operations).
+  on transaction rollback: most likely database storage operations.
 
   For irreversible operations see the new ``AfterResourceChanged`` event.
 
@@ -39,15 +39,15 @@ This document describes changes between each past release.
 - Add method to remove a principal from every user
 - Validate that the client can accept JSON response. (#667)
 - Validate that the client can only send JSON request body. (#667)
-- Added new event ``AfterResourceChanged``, that is sent only when the commit
+- Added new ``AfterResourceChanged`` event, that is sent only when the commit
   in database is successful.
 
   Subscribers of this event can fail, errors are swallowed and logged. The
   final transaction result cannot be altered.
 
-  Since commit occured and operations will not rolledback, subcribers running
-  irreversible actions like sending messages, deleting files, or run asynchronous tasks
-  should subscribe to this event.
+  Since commit occured and operations will not be rolledback, subcribers running
+  irreversible actions should subscribe to this event
+  (like sending messages, deleting files, or run asynchronous tasks).
 
 **Bug fixes**
 

--- a/cliquet/__init__.py
+++ b/cliquet/__init__.py
@@ -55,7 +55,8 @@ DEFAULT_SETTINGS = {
         'cliquet.initialization.setup_authentication',
         'cliquet.initialization.setup_backoff',
         'cliquet.initialization.setup_statsd',
-        'cliquet.initialization.setup_listeners'
+        'cliquet.initialization.setup_listeners',
+        'cliquet.events.setup_transaction_hook',
     ),
     'event_listeners': '',
     'logging_renderer': 'cliquet.logs.ClassicLogRenderer',
@@ -134,7 +135,6 @@ def includeme(config):
     config.registry.api_capabilities = {}
 
     # Resource events helpers.
-    events.setup_transaction_hook(config)
     config.add_request_method(events.get_resource_events,
                               name='get_resource_events')
     config.add_request_method(events.notify_resource_event,

--- a/cliquet/events.py
+++ b/cliquet/events.py
@@ -87,7 +87,7 @@ def setup_transaction_hook(config):
         """Notify the accumulated resource events if transaction succeeds.
         """
         if success:
-            for event in request.get_resource_events(after=True):
+            for event in request.get_resource_events(after_commit=True):
                 try:
                     request.registry.notify(event)
                 except Exception:
@@ -108,7 +108,7 @@ def setup_transaction_hook(config):
     config.add_subscriber(on_new_request, NewRequest)
 
 
-def get_resource_events(request, after=False):
+def get_resource_events(request, after_commit=False):
     """
     Request helper to return the list of events triggered on resources.
     The list is sorted chronologically (see OrderedDict)
@@ -116,7 +116,7 @@ def get_resource_events(request, after=False):
     by_resource = request.bound_data.get("resource_events", {})
     events = []
     for (action, timestamp, impacted, request) in by_resource.values():
-        if after:
+        if after_commit:
             if action == ACTIONS.READ:
                 event_cls = AfterResourceRead
             else:

--- a/cliquet/tests/resource/test_events.py
+++ b/cliquet/tests/resource/test_events.py
@@ -97,7 +97,8 @@ class ResourceChangedTest(BaseEventTest, unittest.TestCase):
         self.app.post_json(self.collection_url, self.body,
                            headers=self.headers, status=201)
         self.assertEqual(len(self.events), 1)
-        self.assertEqual(self.events[0].payload['action'], ACTIONS.CREATE.value)
+        self.assertEqual(self.events[0].payload['action'],
+                         ACTIONS.CREATE.value)
 
     def test_put_sends_create_action(self):
         body = dict(self.body)
@@ -106,7 +107,8 @@ class ResourceChangedTest(BaseEventTest, unittest.TestCase):
         self.app.put_json(record_url, body,
                           headers=self.headers, status=201)
         self.assertEqual(len(self.events), 1)
-        self.assertEqual(self.events[0].payload['action'], ACTIONS.CREATE.value)
+        self.assertEqual(self.events[0].payload['action'],
+                         ACTIONS.CREATE.value)
 
     def test_not_triggered_on_failed_put(self):
         record_id = str(uuid.uuid4())
@@ -116,7 +118,8 @@ class ResourceChangedTest(BaseEventTest, unittest.TestCase):
         headers['If-Match'] = '"12345"'
         self.app.put_json(record_url, self.body, headers=headers, status=412)
         self.assertEqual(len(self.events), 1)
-        self.assertEqual(self.events[0].payload['action'], ACTIONS.CREATE.value)
+        self.assertEqual(self.events[0].payload['action'],
+                         ACTIONS.CREATE.value)
 
     def test_patch_sends_update_action(self):
         resp = self.app.post_json(self.collection_url, self.body,
@@ -127,8 +130,10 @@ class ResourceChangedTest(BaseEventTest, unittest.TestCase):
         self.app.patch_json(record_url, self.body, headers=self.headers,
                             status=200)
         self.assertEqual(len(self.events), 2)
-        self.assertEqual(self.events[0].payload['action'], ACTIONS.CREATE.value)
-        self.assertEqual(self.events[1].payload['action'], ACTIONS.UPDATE.value)
+        self.assertEqual(self.events[0].payload['action'],
+                         ACTIONS.CREATE.value)
+        self.assertEqual(self.events[1].payload['action'],
+                         ACTIONS.UPDATE.value)
 
     def test_put_sends_update_action_if_record_exists(self):
         body = dict(self.body)
@@ -142,8 +147,10 @@ class ResourceChangedTest(BaseEventTest, unittest.TestCase):
                           headers=self.headers, status=200)
 
         self.assertEqual(len(self.events), 2)
-        self.assertEqual(self.events[0].payload['action'], ACTIONS.CREATE.value)
-        self.assertEqual(self.events[1].payload['action'], ACTIONS.UPDATE.value)
+        self.assertEqual(self.events[0].payload['action'],
+                         ACTIONS.CREATE.value)
+        self.assertEqual(self.events[1].payload['action'],
+                         ACTIONS.UPDATE.value)
 
     def test_delete_sends_delete_action(self):
         resp = self.app.post_json(self.collection_url, self.body,
@@ -153,8 +160,10 @@ class ResourceChangedTest(BaseEventTest, unittest.TestCase):
 
         self.app.delete(record_url, headers=self.headers, status=200)
         self.assertEqual(len(self.events), 2)
-        self.assertEqual(self.events[0].payload['action'], ACTIONS.CREATE.value)
-        self.assertEqual(self.events[1].payload['action'], ACTIONS.DELETE.value)
+        self.assertEqual(self.events[0].payload['action'],
+                         ACTIONS.CREATE.value)
+        self.assertEqual(self.events[1].payload['action'],
+                         ACTIONS.DELETE.value)
 
     def test_collection_delete_sends_delete_action(self):
         self.app.post_json(self.collection_url, self.body,
@@ -165,9 +174,12 @@ class ResourceChangedTest(BaseEventTest, unittest.TestCase):
         self.app.delete(self.collection_url, headers=self.headers, status=200)
 
         self.assertEqual(len(self.events), 3)
-        self.assertEqual(self.events[0].payload['action'], ACTIONS.CREATE.value)
-        self.assertEqual(self.events[1].payload['action'], ACTIONS.CREATE.value)
-        self.assertEqual(self.events[2].payload['action'], ACTIONS.DELETE.value)
+        self.assertEqual(self.events[0].payload['action'],
+                         ACTIONS.CREATE.value)
+        self.assertEqual(self.events[1].payload['action'],
+                         ACTIONS.CREATE.value)
+        self.assertEqual(self.events[2].payload['action'],
+                         ACTIONS.DELETE.value)
 
     def test_request_fails_if_notify_fails(self):
         with notif_broken(self.app.app, ResourceChanged):
@@ -182,7 +194,8 @@ class ResourceChangedTest(BaseEventTest, unittest.TestCase):
         app.post_json('/psilos', self.body,
                       headers=self.headers, status=201)
         self.assertEqual(len(self.events), 1)
-        self.assertEqual(self.events[0].payload['action'], ACTIONS.CREATE.value)
+        self.assertEqual(self.events[0].payload['action'],
+                         ACTIONS.CREATE.value)
 
     def test_permissions_are_stripped_from_event_on_protected_resource(self):
         app = self.make_app(settings={

--- a/cliquet/tests/resource/test_events.py
+++ b/cliquet/tests/resource/test_events.py
@@ -5,7 +5,8 @@ from contextlib import contextmanager
 import webtest
 from pyramid.config import Configurator
 
-from cliquet.events import ResourceChanged, ResourceRead, ACTIONS
+from cliquet.events import (ResourceChanged, AfterResourceChanged,
+                            ResourceRead, AfterResourceRead, ACTIONS)
 from cliquet.storage.exceptions import BackendError
 from cliquet.tests.testapp import main as testapp
 from cliquet.tests.support import unittest, BaseWebTest, get_request_class
@@ -13,11 +14,11 @@ from cliquet import statsd
 
 
 @contextmanager
-def notif_broken(app):
+def notif_broken(app, event_cls):
     old = app.registry.notify
 
     def buggy(event):
-        if not isinstance(event, ResourceChanged):
+        if not isinstance(event, event_cls):
             return old(event)
         raise Exception("boom")
 
@@ -27,6 +28,9 @@ def notif_broken(app):
 
 
 class BaseEventTest(BaseWebTest):
+
+    subscribed = tuple()
+
     def setUp(self):
         super(BaseEventTest, self).setUp()
         self.events = []
@@ -42,8 +46,8 @@ class BaseEventTest(BaseWebTest):
     def make_app(self, settings=None):
         settings = self.get_app_settings(settings)
         self.config = Configurator(settings=settings)
-        self.config.add_subscriber(self.listener, ResourceChanged)
-        self.config.add_subscriber(self.listener, ResourceRead)
+        for event_cls in self.subscribed:
+            self.config.add_subscriber(self.listener, event_cls)
         self.config.commit()
         app = testapp(config=self.config)
         app = webtest.TestApp(app)
@@ -53,20 +57,22 @@ class BaseEventTest(BaseWebTest):
 
 class ResourceReadTest(BaseEventTest, unittest.TestCase):
 
+    subscribed = (ResourceRead,)
+
     def test_get_sends_read_event(self):
         resp = self.app.post_json(self.collection_url, self.body,
                                   headers=self.headers, status=201)
         record_id = resp.json['data']['id']
         record_url = self.get_item_url(record_id)
         self.app.get(record_url, headers=self.headers)
-        self.assertEqual(len(self.events), 2)
-        self.assertEqual(self.events[1].payload['action'], ACTIONS.READ.value)
-        self.assertEqual(len(self.events[1].read_records), 1)
+        self.assertEqual(len(self.events), 1)
+        self.assertEqual(self.events[0].payload['action'], ACTIONS.READ.value)
+        self.assertEqual(len(self.events[0].read_records), 1)
 
     def test_collection_get_sends_read_event(self):
         self.app.get(self.collection_url, headers=self.headers)
         self.assertEqual(len(self.events), 1)
-        self.assertEqual(self.events[0].payload['action'], ACTIONS.READ.value)
+        self.assertEqual(self.events[0].payload['action'], ACTIONS.READ)
         self.assertEqual(len(self.events[0].read_records), 0)
 
     def test_post_sends_read_if_id_already_exists(self):
@@ -79,18 +85,19 @@ class ResourceReadTest(BaseEventTest, unittest.TestCase):
         # a second post with the same record id
         self.app.post_json(self.collection_url, body, headers=self.headers,
                            status=200)
-        self.assertEqual(len(self.events), 2)
-        self.assertEqual(self.events[1].payload['action'], ACTIONS.READ.value)
+        self.assertEqual(len(self.events), 1)
+        self.assertEqual(self.events[0].payload['action'], ACTIONS.READ.value)
 
 
 class ResourceChangedTest(BaseEventTest, unittest.TestCase):
+
+    subscribed = (ResourceChanged,)
 
     def test_post_sends_create_action(self):
         self.app.post_json(self.collection_url, self.body,
                            headers=self.headers, status=201)
         self.assertEqual(len(self.events), 1)
-        self.assertEqual(self.events[0].payload['action'],
-                         ACTIONS.CREATE.value)
+        self.assertEqual(self.events[0].payload['action'], ACTIONS.CREATE)
 
     def test_put_sends_create_action(self):
         body = dict(self.body)
@@ -99,8 +106,7 @@ class ResourceChangedTest(BaseEventTest, unittest.TestCase):
         self.app.put_json(record_url, body,
                           headers=self.headers, status=201)
         self.assertEqual(len(self.events), 1)
-        self.assertEqual(self.events[0].payload['action'],
-                         ACTIONS.CREATE.value)
+        self.assertEqual(self.events[0].payload['action'], ACTIONS.CREATE)
 
     def test_not_triggered_on_failed_put(self):
         record_id = str(uuid.uuid4())
@@ -110,8 +116,7 @@ class ResourceChangedTest(BaseEventTest, unittest.TestCase):
         headers['If-Match'] = '"12345"'
         self.app.put_json(record_url, self.body, headers=headers, status=412)
         self.assertEqual(len(self.events), 1)
-        self.assertEqual(self.events[0].payload['action'],
-                         ACTIONS.CREATE.value)
+        self.assertEqual(self.events[0].payload['action'], ACTIONS.CREATE)
 
     def test_patch_sends_update_action(self):
         resp = self.app.post_json(self.collection_url, self.body,
@@ -122,10 +127,8 @@ class ResourceChangedTest(BaseEventTest, unittest.TestCase):
         self.app.patch_json(record_url, self.body, headers=self.headers,
                             status=200)
         self.assertEqual(len(self.events), 2)
-        self.assertEqual(self.events[0].payload['action'],
-                         ACTIONS.CREATE.value)
-        self.assertEqual(self.events[1].payload['action'],
-                         ACTIONS.UPDATE.value)
+        self.assertEqual(self.events[0].payload['action'], ACTIONS.CREATE)
+        self.assertEqual(self.events[1].payload['action'], ACTIONS.UPDATE)
 
     def test_put_sends_update_action_if_record_exists(self):
         body = dict(self.body)
@@ -139,10 +142,8 @@ class ResourceChangedTest(BaseEventTest, unittest.TestCase):
                           headers=self.headers, status=200)
 
         self.assertEqual(len(self.events), 2)
-        self.assertEqual(self.events[0].payload['action'],
-                         ACTIONS.CREATE.value)
-        self.assertEqual(self.events[1].payload['action'],
-                         ACTIONS.UPDATE.value)
+        self.assertEqual(self.events[0].payload['action'], ACTIONS.CREATE)
+        self.assertEqual(self.events[1].payload['action'], ACTIONS.UPDATE)
 
     def test_delete_sends_delete_action(self):
         resp = self.app.post_json(self.collection_url, self.body,
@@ -152,10 +153,8 @@ class ResourceChangedTest(BaseEventTest, unittest.TestCase):
 
         self.app.delete(record_url, headers=self.headers, status=200)
         self.assertEqual(len(self.events), 2)
-        self.assertEqual(self.events[0].payload['action'],
-                         ACTIONS.CREATE.value)
-        self.assertEqual(self.events[1].payload['action'],
-                         ACTIONS.DELETE.value)
+        self.assertEqual(self.events[0].payload['action'], ACTIONS.CREATE)
+        self.assertEqual(self.events[1].payload['action'], ACTIONS.DELETE)
 
     def test_collection_delete_sends_delete_action(self):
         self.app.post_json(self.collection_url, self.body,
@@ -166,23 +165,14 @@ class ResourceChangedTest(BaseEventTest, unittest.TestCase):
         self.app.delete(self.collection_url, headers=self.headers, status=200)
 
         self.assertEqual(len(self.events), 3)
-        self.assertEqual(self.events[0].payload['action'],
-                         ACTIONS.CREATE.value)
-        self.assertEqual(self.events[1].payload['action'],
-                         ACTIONS.CREATE.value)
-        self.assertEqual(self.events[2].payload['action'],
-                         ACTIONS.DELETE.value)
+        self.assertEqual(self.events[0].payload['action'], ACTIONS.CREATE)
+        self.assertEqual(self.events[1].payload['action'], ACTIONS.CREATE)
+        self.assertEqual(self.events[2].payload['action'], ACTIONS.DELETE)
 
-    def test_not_triggered_if_notify_fails(self):
-        # if the notification system is broken we should still see
-        # the record created
-        with notif_broken(self.app.app):
-            resp = self.app.post_json(self.collection_url, self.body,
-                                      headers=self.headers, status=201)
-
-        record = resp.json['data']
-        record_url = self.get_item_url(record['id'])
-        self.assertNotEqual(record_url, None)
+    def test_request_fails_if_notify_fails(self):
+        with notif_broken(self.app.app, ResourceChanged):
+            self.app.post_json(self.collection_url, self.body,
+                               headers=self.headers, status=500)
         self.assertEqual(len(self.events), 0)
 
     def test_triggered_on_protected_resource(self):
@@ -192,8 +182,7 @@ class ResourceChangedTest(BaseEventTest, unittest.TestCase):
         app.post_json('/psilos', self.body,
                       headers=self.headers, status=201)
         self.assertEqual(len(self.events), 1)
-        self.assertEqual(self.events[0].payload['action'],
-                         ACTIONS.CREATE.value)
+        self.assertEqual(self.events[0].payload['action'], ACTIONS.CREATE)
 
     def test_permissions_are_stripped_from_event_on_protected_resource(self):
         app = self.make_app(settings={
@@ -210,7 +199,33 @@ class ResourceChangedTest(BaseEventTest, unittest.TestCase):
         self.assertNotIn('__permissions__', impacted_records[0]['old'])
 
 
+class AfterResourceChangedTest(BaseEventTest, unittest.TestCase):
+
+    subscribed = (AfterResourceChanged,)
+
+    def test_request_succeeds_if_notify_fails(self):
+        with notif_broken(self.app.app, AfterResourceChanged):
+            self.app.post_json(self.collection_url, self.body,
+                               headers=self.headers)
+
+        self.assertEqual(len(self.events), 0)
+
+
+class AfterResourceReadTest(BaseEventTest, unittest.TestCase):
+
+    subscribed = (AfterResourceRead,)
+
+    def test_request_succeeds_if_notify_fails(self):
+        with notif_broken(self.app.app, AfterResourceChanged):
+            self.app.post_json(self.collection_url, self.body,
+                               headers=self.headers)
+
+        self.assertEqual(len(self.events), 0)
+
+
 class ImpactedRecordsTest(BaseEventTest, unittest.TestCase):
+
+    subscribed = (ResourceChanged,)
 
     def test_create_has_new_record_and_no_old_in_payload(self):
         resp = self.app.post_json(self.collection_url, self.body,
@@ -271,6 +286,9 @@ class ImpactedRecordsTest(BaseEventTest, unittest.TestCase):
 
 
 class BatchEventsTest(BaseEventTest, unittest.TestCase):
+
+    subscribed = (ResourceChanged, ResourceRead)
+
     def test_impacted_records_are_merged(self):
         record_id = str(uuid.uuid4())
         record_url = self.get_item_url(record_id)
@@ -290,11 +308,11 @@ class BatchEventsTest(BaseEventTest, unittest.TestCase):
         self.assertEqual(len(self.events), 3)
 
         create_event = self.events[0]
-        self.assertEqual(create_event.payload['action'], ACTIONS.CREATE.value)
+        self.assertEqual(create_event.payload['action'], 'create')
         self.assertEqual(len(create_event.impacted_records), 1)
         self.assertNotIn('old', create_event.impacted_records[0])
         update_event = self.events[1]
-        self.assertEqual(update_event.payload['action'], ACTIONS.UPDATE.value)
+        self.assertEqual(update_event.payload['action'], 'update')
         impacted = update_event.impacted_records
         self.assertEqual(len(impacted), 2)
         self.assertEqual(impacted[0]['old']['name'], 'foo')
@@ -302,7 +320,7 @@ class BatchEventsTest(BaseEventTest, unittest.TestCase):
         self.assertEqual(impacted[1]['old']['name'], 'bar')
         self.assertEqual(impacted[1]['new']['name'], 'baz')
         delete_event = self.events[2]
-        self.assertEqual(delete_event.payload['action'], ACTIONS.DELETE.value)
+        self.assertEqual(delete_event.payload['action'], 'delete')
         self.assertEqual(len(delete_event.impacted_records), 1)
         self.assertNotIn('new', delete_event.impacted_records[0])
 

--- a/cliquet/tests/resource/test_events.py
+++ b/cliquet/tests/resource/test_events.py
@@ -72,7 +72,7 @@ class ResourceReadTest(BaseEventTest, unittest.TestCase):
     def test_collection_get_sends_read_event(self):
         self.app.get(self.collection_url, headers=self.headers)
         self.assertEqual(len(self.events), 1)
-        self.assertEqual(self.events[0].payload['action'], ACTIONS.READ)
+        self.assertEqual(self.events[0].payload['action'], ACTIONS.READ.value)
         self.assertEqual(len(self.events[0].read_records), 0)
 
     def test_post_sends_read_if_id_already_exists(self):
@@ -97,7 +97,7 @@ class ResourceChangedTest(BaseEventTest, unittest.TestCase):
         self.app.post_json(self.collection_url, self.body,
                            headers=self.headers, status=201)
         self.assertEqual(len(self.events), 1)
-        self.assertEqual(self.events[0].payload['action'], ACTIONS.CREATE)
+        self.assertEqual(self.events[0].payload['action'], ACTIONS.CREATE.value)
 
     def test_put_sends_create_action(self):
         body = dict(self.body)
@@ -106,7 +106,7 @@ class ResourceChangedTest(BaseEventTest, unittest.TestCase):
         self.app.put_json(record_url, body,
                           headers=self.headers, status=201)
         self.assertEqual(len(self.events), 1)
-        self.assertEqual(self.events[0].payload['action'], ACTIONS.CREATE)
+        self.assertEqual(self.events[0].payload['action'], ACTIONS.CREATE.value)
 
     def test_not_triggered_on_failed_put(self):
         record_id = str(uuid.uuid4())
@@ -116,7 +116,7 @@ class ResourceChangedTest(BaseEventTest, unittest.TestCase):
         headers['If-Match'] = '"12345"'
         self.app.put_json(record_url, self.body, headers=headers, status=412)
         self.assertEqual(len(self.events), 1)
-        self.assertEqual(self.events[0].payload['action'], ACTIONS.CREATE)
+        self.assertEqual(self.events[0].payload['action'], ACTIONS.CREATE.value)
 
     def test_patch_sends_update_action(self):
         resp = self.app.post_json(self.collection_url, self.body,
@@ -127,8 +127,8 @@ class ResourceChangedTest(BaseEventTest, unittest.TestCase):
         self.app.patch_json(record_url, self.body, headers=self.headers,
                             status=200)
         self.assertEqual(len(self.events), 2)
-        self.assertEqual(self.events[0].payload['action'], ACTIONS.CREATE)
-        self.assertEqual(self.events[1].payload['action'], ACTIONS.UPDATE)
+        self.assertEqual(self.events[0].payload['action'], ACTIONS.CREATE.value)
+        self.assertEqual(self.events[1].payload['action'], ACTIONS.UPDATE.value)
 
     def test_put_sends_update_action_if_record_exists(self):
         body = dict(self.body)
@@ -142,8 +142,8 @@ class ResourceChangedTest(BaseEventTest, unittest.TestCase):
                           headers=self.headers, status=200)
 
         self.assertEqual(len(self.events), 2)
-        self.assertEqual(self.events[0].payload['action'], ACTIONS.CREATE)
-        self.assertEqual(self.events[1].payload['action'], ACTIONS.UPDATE)
+        self.assertEqual(self.events[0].payload['action'], ACTIONS.CREATE.value)
+        self.assertEqual(self.events[1].payload['action'], ACTIONS.UPDATE.value)
 
     def test_delete_sends_delete_action(self):
         resp = self.app.post_json(self.collection_url, self.body,
@@ -153,8 +153,8 @@ class ResourceChangedTest(BaseEventTest, unittest.TestCase):
 
         self.app.delete(record_url, headers=self.headers, status=200)
         self.assertEqual(len(self.events), 2)
-        self.assertEqual(self.events[0].payload['action'], ACTIONS.CREATE)
-        self.assertEqual(self.events[1].payload['action'], ACTIONS.DELETE)
+        self.assertEqual(self.events[0].payload['action'], ACTIONS.CREATE.value)
+        self.assertEqual(self.events[1].payload['action'], ACTIONS.DELETE.value)
 
     def test_collection_delete_sends_delete_action(self):
         self.app.post_json(self.collection_url, self.body,
@@ -165,9 +165,9 @@ class ResourceChangedTest(BaseEventTest, unittest.TestCase):
         self.app.delete(self.collection_url, headers=self.headers, status=200)
 
         self.assertEqual(len(self.events), 3)
-        self.assertEqual(self.events[0].payload['action'], ACTIONS.CREATE)
-        self.assertEqual(self.events[1].payload['action'], ACTIONS.CREATE)
-        self.assertEqual(self.events[2].payload['action'], ACTIONS.DELETE)
+        self.assertEqual(self.events[0].payload['action'], ACTIONS.CREATE.value)
+        self.assertEqual(self.events[1].payload['action'], ACTIONS.CREATE.value)
+        self.assertEqual(self.events[2].payload['action'], ACTIONS.DELETE.value)
 
     def test_request_fails_if_notify_fails(self):
         with notif_broken(self.app.app, ResourceChanged):
@@ -182,7 +182,7 @@ class ResourceChangedTest(BaseEventTest, unittest.TestCase):
         app.post_json('/psilos', self.body,
                       headers=self.headers, status=201)
         self.assertEqual(len(self.events), 1)
-        self.assertEqual(self.events[0].payload['action'], ACTIONS.CREATE)
+        self.assertEqual(self.events[0].payload['action'], ACTIONS.CREATE.value)
 
     def test_permissions_are_stripped_from_event_on_protected_resource(self):
         app = self.make_app(settings={

--- a/cliquet/tests/support.py
+++ b/cliquet/tests/support.py
@@ -31,7 +31,7 @@ class DummyRequest(mock.MagicMock):
     def __init__(self, *args, **kwargs):
         super(DummyRequest, self).__init__(*args, **kwargs)
         self.upath_info = '/v0/'
-        self.registry = mock.MagicMock(settings=DEFAULT_SETTINGS)
+        self.registry = mock.MagicMock(settings=DEFAULT_SETTINGS.copy())
         self.registry.id_generator = generators.UUID4()
         self.GET = {}
         self.headers = {}

--- a/cliquet/tests/test_views_transaction.py
+++ b/cliquet/tests/test_views_transaction.py
@@ -11,6 +11,16 @@ from .support import (BaseWebTest, unittest, skip_if_no_postgresql,
 
 
 class PostgreSQLTest(BaseWebTest):
+    def setUp(self):
+        super(PostgreSQLTest, self).setUp()
+        self.storage.initialize_schema()
+        self.permission.initialize_schema()
+
+    def tearDown(self):
+        super(BaseWebTest, self).tearDown()
+        self.storage.flush()
+        self.permission.flush()
+
     def get_app_settings(self, extras=None):
         settings = super(PostgreSQLTest, self).get_app_settings(extras)
         if sqlalchemy is not None:
@@ -116,11 +126,10 @@ class TransactionEventsTest(PostgreSQLTest, unittest.TestCase):
     def make_app_with_subscribers(self, subscribers):
         settings = self.get_app_settings({})
         config = testing.setUp(settings=settings)
-        app = self.make_app(config=config)
         for event, subscriber in subscribers:
             config.add_subscriber(subscriber, event)
         config.commit()
-        return app
+        return self.make_app(config=config)
 
     def send_batch_create(self, app, **kwargs):
         body = {

--- a/cliquet_docs/reference/configuration.rst
+++ b/cliquet_docs/reference/configuration.rst
@@ -526,13 +526,17 @@ possible to change the ``initialization_sequence`` setting.
 
 .. code-block:: ini
 
-    cliquet.initialization_sequence = cliquet.initialization.setup_json_serializer
+    cliquet.initialization_sequence = cliquet.initialization.setup_request_bound_data
+                                      cliquet.initialization.setup_json_serializer
                                       cliquet.initialization.setup_logging
                                       cliquet.initialization.setup_storage
+                                      cliquet.initialization.setup_permission
                                       cliquet.initialization.setup_cache
                                       cliquet.initialization.setup_requests_scheme
                                       cliquet.initialization.setup_version_redirection
                                       cliquet.initialization.setup_deprecation
                                       cliquet.initialization.setup_authentication
                                       cliquet.initialization.setup_backoff
-                                      cliquet.initialization.setup_stats
+                                      cliquet.initialization.setup_statsd
+                                      cliquet.initialization.setup_listeners
+                                      cliquet.events.setup_transaction_hook

--- a/cliquet_docs/reference/notifications.rst
+++ b/cliquet_docs/reference/notifications.rst
@@ -7,27 +7,73 @@ Knowing some records have been modified in a resource is very
 useful to integrate a Cliquet-based application with other services.
 
 For example, a search service that gets notified everytime something
-has changed, can continuously update its indexes.
+has changed, can continuously update its index.
 
-Cliquet leverages Pyramid's built-in event system and produces
-a :class:`cliquet.events.ResourceChanged` event everytime a record in a
-:ref:`resource` has been modified.
+Cliquet leverages Pyramid's built-in event system and produces the following
+events:
 
-Event listeners can then pick up those events and act upon them.
+- :class:`cliquet.events.ResourceRead`: a read operation occured on the resource.
+
+- :class:`cliquet.events.ResourceChanged`: a resource **is being changed**. This
+  event occurs synchronously within the transaction and within the
+  request/response cycle. Commit is not yet done and rollback is still possible.
+
+  Subscribers of this event are likely to perform database operations,
+  alter the server response, or cancel the transaction (by raising an HTTP
+  exeception for example).
+  Do not subscribe to this event for operations that will not be rolled-back
+  automatically.
+
+- :class:`cliquet.events.AfterResourceChanged`: a resource **was changed** and
+  **committed**.
+
+  Subscribers of this event can fail, errors are swallowed and logged. The
+  final transaction result (or response) cannot be altered.
+
+  Subscribers of this event are likely to perform irreversible actions that
+  requires data to be committed in database
+  (like sending messages, deleting files on disk, or run asynchronous tasks).
+
+
+Event subscribers can then pick up those events and act upon them.
+
+.. code-block:: python
+
+    from cliquet.events import AfterResourceChanged
+
+
+    def on_resource_changed(event):
+        for change in event.impacted_records:
+            start_download(change['new']['url'])
+
+    config.add_subscriber(on_resource_changed, AfterResourceChanged)
+
+
+Transactions
+------------
+
+Only one event is sent per transaction, per resource and per action.
+
+In other words, if every requests of a :ref:`batch requests <batch>`_
+perform the same action on the same resource, only one event will be sent.
+
+The ``AfterResourceChanged`` is sent only if the transaction was comitted
+successfully.
+
+It is possible to cancel the current transaction by raising an HTTP Exception
+from a ``ResourceChanged`` event. For example:
 
 .. code-block:: python
 
     from cliquet.events import ResourceChanged
+    from pyramid import httpexceptions
 
+    def check_quota(event):
+         max_quota = event.request.registry.settings['max_quota']
+         if check_quota(event, max_quota):
+            raise httpexceptions.HTTPInsufficientStorage()
 
-    def on_resource_changed(event):
-        resource_name = event.payload['resource_name']
-        action = event.payload['action']
-
-        if resource_name == 'article' and action == 'create':
-            start_download(event.payload['article_id'])
-
-    config.add_subscriber(on_resource_changed, ResourceChanged)
+    config.add_subscriber(check_quota, ResourceChanged)
 
 
 Filtering
@@ -49,9 +95,8 @@ For example:
 Payload
 -------
 
-
-The :class:`cliquet.events.ResourceChanged` event contains a ``payload`` attribute with
-the following information:
+The :class:`cliquet.events.ResourceChanged` and :class:`cliquet.events.AfterResourceChanged`
+events contain a ``payload`` attribute with the following information:
 
 - **timestamp**: the time of the event
 - **action**: what happened. 'create', 'update' or 'delete'
@@ -69,7 +114,7 @@ events, only ``new`` is provided. For deletion events, only ``old`` is provided.
 This also allows listeners to react on particular field change or handle *diff*
 between versions.
 
-Example, when deleting a collection:
+Example, when deleting a collection with two records:
 
 ::
 


### PR DESCRIPTION
(revamp of #644)

* [x] Approve design
* [x] Fix tests side-effects (whole test suite fails, running test_views_transactions succeeds)
* [ ] ~~Change subscribtion of listeners to `AfterResourceChanged` (because of *fire-n-forget*)~~ #647 
* [x] Update documentation

**tldr:** We need two kinds of events: `before` events to run within transaction and «rollbackable». `after` events to run irreversible actions (that can fail)

Feedback/Critics/Stones/Hugs/Flowers welcome!
