### PR TITLE
python installation command updated

### DIFF
--- a/cliquet_docs/reference/installation.rst
+++ b/cliquet_docs/reference/installation.rst
@@ -65,7 +65,7 @@ OS X
 
 ::
 
-    brew install python3.4
+    brew install python3
 
 
 Cryptography libraries


### PR DESCRIPTION
`brew install python3.4` gives the following error : 

```
brew install python3.4
Error: No available formula with the name "python3.4"
==> Searching for similarly named formulae...
Error: No similarly named formulae found.
==> Searching taps...
Error: No formulae found in taps.
```