### PR TITLE
Get requests is sorted according to last_modified

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ This document describes changes between each past release.
 
 - Resource events are not emitted if the transaction is rolledback (e.g. a batch
   subrequest fails) (#634)
+- Get requests is sorted according to last_modified (#662)
 
 **Internal changes**
 

--- a/cliquet/resource/__init__.py
+++ b/cliquet/resource/__init__.py
@@ -232,9 +232,6 @@ class UserResource(object):
         pagination_rules, offset = self._extract_pagination_rules_from_token(
             limit, sorting)
 
-        #Sort the Get requests according to last_modified
-        sorting.append(Sort('last_modified',-1))
-
 
         records, total_records = self.model.get_records(
             filters=filters,
@@ -944,7 +941,7 @@ class UserResource(object):
                 direction = -1 if order == '-' else 1
                 sorting.append(Sort(field, direction))
 
-        if not modified_field_used and limit:
+        if not modified_field_used:
             # Add a sort by the ``modified_field`` in descending order
             # useful for pagination
             sorting.append(Sort(self.model.modified_field, -1))

--- a/cliquet/resource/__init__.py
+++ b/cliquet/resource/__init__.py
@@ -232,6 +232,10 @@ class UserResource(object):
         pagination_rules, offset = self._extract_pagination_rules_from_token(
             limit, sorting)
 
+        #Sort the Get requests according to last_modified
+        sorting.append(Sort('last_modified',-1))
+
+
         records, total_records = self.model.get_records(
             filters=filters,
             sorting=sorting,

--- a/cliquet/tests/resource/test_sort.py
+++ b/cliquet/tests/resource/test_sort.py
@@ -100,3 +100,9 @@ class SortingTest(BaseTest):
         result = self.resource.collection_get()
         self.assertEqual(result['data'][0]['unread'], False)
         self.assertEqual(result['data'][-1]['unread'], True)
+
+    def test_default_sort_is_last_modified_desc_by_default(self):
+        self.resource.request.GET = {'_sort': ''}
+        result = self.resource.collection_get()
+        tstamp = self.model.timestamp()
+        self.assertEqual(result['data'][0]['last_modified'], tstamp)

--- a/cliquet/tests/resource/test_sort.py
+++ b/cliquet/tests/resource/test_sort.py
@@ -106,3 +106,10 @@ class SortingTest(BaseTest):
         result = self.resource.collection_get()
         tstamp = self.model.timestamp()
         self.assertEqual(result['data'][0]['last_modified'], tstamp)
+
+    def test_default_sort_is_last_modified_records_have_same_status(self):
+        self.resource.request.GET = {'_sort': 'status'}
+        result = self.resource.collection_get()
+        self.assertEqual(result['data'][0]['status'], 0)
+        self.assertEqual(result['data'][1]['status'], 0)
+        self.assertEqual(result['data'][0]['last_modified']>result['data'][1]['last_modified'],True )


### PR DESCRIPTION
This solves the issue https://github.com/Kinto/kinto/issues/434 and sorts the records according to the `last_modified` attribute. 