### PR TITLE
Fix PG behaviour when specifying timestamps in the past

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ This document describes changes between each past release.
 
 - Resource events are not emitted if the transaction is rolledback (e.g. a batch
   subrequest fails) (#634)
+- Fix a migration of PostgreSQL schema introduced in #604 that was never executed
 - Fix PostgreSQL backend timestamps when collection is empty (ref Kinto/kinto#433)
 
 **Internal changes**

--- a/cliquet/resource/__init__.py
+++ b/cliquet/resource/__init__.py
@@ -558,8 +558,8 @@ class UserResource(object):
             return new
 
         # Drop the new last_modified if lesser or equal to the old one.
-        is_greater = new_last_modified <= old[self.model.modified_field]
-        if new_last_modified and is_greater:
+        is_less_or_equal = new_last_modified <= old[self.model.modified_field]
+        if new_last_modified and is_less_or_equal:
             del new[self.model.modified_field]
 
         return new

--- a/cliquet/resource/__init__.py
+++ b/cliquet/resource/__init__.py
@@ -512,6 +512,19 @@ class UserResource(object):
 
         # Retreive the last_modified information from a querystring if present.
         last_modified = self.request.GET.get('last_modified')
+        if last_modified:
+            last_modified = native_value(last_modified.strip('"'))
+            if not isinstance(last_modified, six.integer_types):
+                error_details = {
+                    'name': 'last_modified',
+                    'location': 'querystring',
+                    'description': 'Invalid value for %s' % last_modified
+                }
+                raise_invalid(self.request, **error_details)
+
+            # If less or equal than current record. Ignore it.
+            if last_modified <= record[self.model.modified_field]:
+                last_modified = None
 
         deleted = self.model.delete_record(record, last_modified=last_modified)
         return self.postprocess(deleted, action=ACTIONS.DELETE)

--- a/cliquet/storage/postgresql/__init__.py
+++ b/cliquet/storage/postgresql/__init__.py
@@ -66,7 +66,7 @@ class Storage(StorageBase):
 
     """  # NOQA
 
-    schema_version = 9
+    schema_version = 10
 
     def __init__(self, client, max_fetch_size, *args, **kwargs):
         super(Storage, self).__init__(*args, **kwargs)

--- a/cliquet/storage/postgresql/__init__.py
+++ b/cliquet/storage/postgresql/__init__.py
@@ -184,6 +184,7 @@ class Storage(StorageBase):
         query = """
         DELETE FROM deleted;
         DELETE FROM records;
+        DELETE FROM timestamps;
         DELETE FROM metadata;
         """
         with self.client.connect(force_commit=True) as conn:

--- a/cliquet/storage/postgresql/__init__.py
+++ b/cliquet/storage/postgresql/__init__.py
@@ -158,7 +158,7 @@ class Storage(StorageBase):
         SELECT value AS version
           FROM metadata
          WHERE name = 'storage_schema_version'
-         ORDER BY value DESC;
+         ORDER BY LPAD(value, 3, '0') DESC;
         """
         with self.client.connect() as conn:
             result = conn.execute(query)

--- a/cliquet/storage/postgresql/migrations/migration_008_009.sql
+++ b/cliquet/storage/postgresql/migrations/migration_008_009.sql
@@ -1,32 +1,9 @@
-CREATE TABLE IF NOT EXISTS timestamps (
-  parent_id TEXT NOT NULL,
-  collection_id TEXT NOT NULL,
-  last_modified TIMESTAMP NOT NULL,
-  PRIMARY KEY (parent_id, collection_id)
-);
-
-
-CREATE OR REPLACE FUNCTION collection_timestamp(uid VARCHAR, resource VARCHAR)
-RETURNS TIMESTAMP AS $$
-DECLARE
-    ts TIMESTAMP;
+CREATE OR REPLACE FUNCTION from_epoch(epoch BIGINT) RETURNS TIMESTAMP AS $$
 BEGIN
-    ts := NULL;
-
-    SELECT last_modified INTO ts
-      FROM timestamps
-     WHERE parent_id = uid
-       AND collection_id = resource;
-
-    IF ts IS NULL THEN
-      ts := clock_timestamp();
-      INSERT INTO timestamps (parent_id, collection_id, last_modified)
-      VALUES (uid, resource, ts);
-    END IF;
-
-    RETURN ts;
+    RETURN TIMESTAMP WITH TIME ZONE 'epoch' + epoch * INTERVAL '1 millisecond';
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql
+IMMUTABLE;
 
 
 CREATE OR REPLACE FUNCTION bump_timestamp()
@@ -45,26 +22,15 @@ BEGIN
     -- an error (operation is cancelled).
     -- See https://github.com/mozilla-services/cliquet/issues/25
     --
+    previous := collection_timestamp(NEW.parent_id, NEW.collection_id);
+
     IF NEW.last_modified IS NULL THEN
-        previous := collection_timestamp(NEW.parent_id, NEW.collection_id);
         current := clock_timestamp();
         IF previous >= current THEN
             current := previous + INTERVAL '1 milliseconds';
         END IF;
         NEW.last_modified := current;
     END IF;
-
-    --
-    -- Upsert current collection timestamp.
-    --
-    WITH upsert AS (
-        UPDATE timestamps SET last_modified = NEW.last_modified
-         WHERE parent_id = NEW.parent_id AND collection_id = NEW.collection_id
-        RETURNING *
-    )
-    INSERT INTO timestamps (parent_id, collection_id, last_modified)
-    SELECT NEW.parent_id, NEW.collection_id, NEW.last_modified
-    WHERE NOT EXISTS (SELECT * FROM upsert);
 
     RETURN NEW;
 END;

--- a/cliquet/storage/postgresql/migrations/migration_009_010.sql
+++ b/cliquet/storage/postgresql/migrations/migration_009_010.sql
@@ -1,0 +1,75 @@
+CREATE TABLE IF NOT EXISTS timestamps (
+  parent_id TEXT NOT NULL,
+  collection_id TEXT NOT NULL,
+  last_modified TIMESTAMP NOT NULL,
+  PRIMARY KEY (parent_id, collection_id)
+);
+
+
+CREATE OR REPLACE FUNCTION collection_timestamp(uid VARCHAR, resource VARCHAR)
+RETURNS TIMESTAMP AS $$
+DECLARE
+    ts TIMESTAMP;
+BEGIN
+    ts := NULL;
+
+    SELECT last_modified INTO ts
+      FROM timestamps
+     WHERE parent_id = uid
+       AND collection_id = resource;
+
+    IF ts IS NULL THEN
+      ts := clock_timestamp();
+      INSERT INTO timestamps (parent_id, collection_id, last_modified)
+      VALUES (uid, resource, ts);
+    END IF;
+
+    RETURN ts;
+END;
+$$ LANGUAGE plpgsql;
+
+
+CREATE OR REPLACE FUNCTION bump_timestamp()
+RETURNS trigger AS $$
+DECLARE
+    previous TIMESTAMP;
+    current TIMESTAMP;
+
+BEGIN
+    --
+    -- This bumps the current timestamp to 1 msec in the future if the previous
+    -- timestamp is equal to the current one (or higher if was bumped already).
+    --
+    -- If a bunch of requests from the same user on the same collection
+    -- arrive in the same millisecond, the unicity constraint can raise
+    -- an error (operation is cancelled).
+    -- See https://github.com/mozilla-services/cliquet/issues/25
+    --
+    IF NEW.last_modified IS NULL THEN
+        previous := collection_timestamp(NEW.parent_id, NEW.collection_id);
+        current := clock_timestamp();
+        IF previous >= current THEN
+            current := previous + INTERVAL '1 milliseconds';
+        END IF;
+        NEW.last_modified := current;
+    END IF;
+
+    --
+    -- Upsert current collection timestamp.
+    --
+    WITH upsert AS (
+        UPDATE timestamps SET last_modified = NEW.last_modified
+         WHERE parent_id = NEW.parent_id AND collection_id = NEW.collection_id
+        RETURNING *
+    )
+    INSERT INTO timestamps (parent_id, collection_id, last_modified)
+    SELECT NEW.parent_id, NEW.collection_id, NEW.last_modified
+    WHERE NOT EXISTS (SELECT * FROM upsert);
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+
+-- Bump storage schema version.
+INSERT INTO metadata (name, value) VALUES ('storage_schema_version', '10');

--- a/cliquet/storage/postgresql/migrations/migration_009_010.sql
+++ b/cliquet/storage/postgresql/migrations/migration_009_010.sql
@@ -36,6 +36,12 @@ DECLARE
     current TIMESTAMP;
 
 BEGIN
+    previous := NULL;
+    SELECT last_modified INTO previous
+      FROM timestamps
+     WHERE parent_id = NEW.parent_id
+       AND collection_id = NEW.collection_id;
+
     --
     -- This bumps the current timestamp to 1 msec in the future if the previous
     -- timestamp is equal to the current one (or higher if was bumped already).
@@ -45,25 +51,32 @@ BEGIN
     -- an error (operation is cancelled).
     -- See https://github.com/mozilla-services/cliquet/issues/25
     --
+    current := clock_timestamp();
+    IF previous IS NOT NULL AND previous >= current THEN
+        current := previous + INTERVAL '1 milliseconds';
+    END IF;
+
+
     IF NEW.last_modified IS NULL THEN
-        previous := collection_timestamp(NEW.parent_id, NEW.collection_id);
-        current := clock_timestamp();
-        IF previous >= current THEN
-            current := previous + INTERVAL '1 milliseconds';
-        END IF;
+        -- If record does not carry last-modified, assign it to current.
         NEW.last_modified := current;
+    ELSE
+        -- Use record last-modified as collection timestamp.
+        IF previous IS NULL OR NEW.last_modified > previous THEN
+            current := NEW.last_modified;
+        END IF;
     END IF;
 
     --
     -- Upsert current collection timestamp.
     --
     WITH upsert AS (
-        UPDATE timestamps SET last_modified = NEW.last_modified
+        UPDATE timestamps SET last_modified = current
          WHERE parent_id = NEW.parent_id AND collection_id = NEW.collection_id
         RETURNING *
     )
     INSERT INTO timestamps (parent_id, collection_id, last_modified)
-    SELECT NEW.parent_id, NEW.collection_id, NEW.last_modified
+    SELECT NEW.parent_id, NEW.collection_id, current
     WHERE NOT EXISTS (SELECT * FROM upsert);
 
     RETURN NEW;

--- a/cliquet/storage/postgresql/schema.sql
+++ b/cliquet/storage/postgresql/schema.sql
@@ -228,4 +228,4 @@ INSERT INTO metadata (name, value) VALUES ('created_at', NOW()::TEXT);
 
 -- Set storage schema version.
 -- Should match ``cliquet.storage.postgresql.PostgreSQL.schema_version``
-INSERT INTO metadata (name, value) VALUES ('storage_schema_version', '9');
+INSERT INTO metadata (name, value) VALUES ('storage_schema_version', '10');

--- a/cliquet_docs/api/resource.rst
+++ b/cliquet_docs/api/resource.rst
@@ -432,8 +432,8 @@ When a record is created, the timestamp of the collection is incremented.
 It is possible to force the timestamp if the specified record has a
 ``last_modified`` attribute.
 
-The specified value will be ignored if it is less than the current collection
-timestamp.
+If the specified timestamp is in the past, the collection timestamp does not
+take the value of the created record but is bumped into the future as usual.
 
 
 HTTP Status Codes
@@ -597,8 +597,8 @@ When a record is deleted, the timestamp of the collection is incremented.
 It is possible to force the timestamp by passing it in the
 querystring with ``?last_modified=<value>``.
 
-The specified value will be ignored if it is less than the current collection
-timestamp.
+If the specified timestamp is in the past, the collection timestamp does not
+take the value of the deleted record but is bumped into the future as usual.
 
 
 HTTP Status Code
@@ -682,10 +682,11 @@ When a record is created or replaced, the timestamp of the collection is increme
 It is possible to force the timestamp if the specified record has a
 ``last_modified`` attribute.
 
-The specified value will be ignored if:
+For replace, if the specified timestamp is less or equal than the existing record,
+the value is simply ignored and the timestamp is bumped into the future as usual.
 
-* it is less than the current collection timestamp;
-* it is less or equal than the previously existing record timestamp (for replace).
+For creation, if the specified timestamp is in the past, the collection timestamp does not
+take the value of the created/updated record but is bumped into the future as usual.
 
 
 HTTP Status Code
@@ -807,11 +808,8 @@ When a record is modified, the timestamp of the collection is incremented.
 It is possible to force the timestamp if the specified record has a
 ``last_modified`` attribute.
 
-
-The specified value will be ignored if:
-
-* it is less than the current collection timestamp;
-* it is less or equal than the previously existing record timestamp.
+If the specified timestamp is less or equal than the existing record,
+the value is simply ignored and the timestamp is bumped into the future as usual.
 
 
 HTTP Status Code

--- a/cliquet_docs/api/resource.rst
+++ b/cliquet_docs/api/resource.rst
@@ -424,6 +424,18 @@ A ``details`` attribute in the response provides the offending record and
 field name. See :ref:`dedicated section about errors <error-responses>`.
 
 
+Timestamp
+---------
+
+When a record is created, the timestamp of the collection is incremented.
+
+It is possible to force the timestamp if the specified record has a
+``last_modified`` attribute.
+
+The specified value will be ignored if it is less than the current collection
+timestamp.
+
+
 HTTP Status Codes
 -----------------
 
@@ -433,6 +445,10 @@ HTTP Status Codes
 * ``400 Bad Request``: The request body is invalid
 * ``409 Conflict``: Unicity constraint on fields is violated
 * ``412 Precondition Failed``: Collection changed since value in ``If-Match`` header
+
+.. versionadded:: 2.13::
+
+  Enforcement of the timestamp value for records has been added.
 
 
 DELETE /{collection}
@@ -567,23 +583,33 @@ The consumer might decide to ignore it.
 If the request header ``If-Match`` is provided, and if the record has
 changed meanwhile, a ``412 Precondition failed`` error is returned.
 
-The timestamp value of the deleted record can be enforced via the
-``last_modified`` QueryString parameter.
-
 .. note::
 
     Once deleted, a record will appear in the collection when polling for changes,
     with a deleted status (``delete=true``) and will have most of its fields empty.
 
-.. versionadded:: 2.13::
 
-  Enforcement of the timestamp value for records has been added.
+Timestamp
+---------
+
+When a record is deleted, the timestamp of the collection is incremented.
+
+It is possible to force the timestamp by passing it in the
+querystring with ``?last_modified=<value>``.
+
+The specified value will be ignored if it is less than the current collection
+timestamp.
+
 
 HTTP Status Code
 ----------------
 
 * ``200 OK``: The record was deleted
 * ``412 Precondition Failed``: Record changed since value in ``If-Match`` header
+
+.. versionadded:: 2.13::
+
+  Enforcement of the timestamp value for records has been added.
 
 
 PUT /{collection}/<id>
@@ -608,9 +634,6 @@ Validation and conflicts behaviour is similar to creating records (``POST``).
 If the request header ``If-Match`` is provided, and if the record has
 changed meanwhile, a ``412 Precondition failed`` error is returned.
 
-.. versionadded:: 2.13::
-
-  Enforcement of the timestamp value for records has been added.
 
 **Request**:
 
@@ -651,6 +674,20 @@ changed meanwhile, a ``412 Precondition failed`` error is returned.
     }
 
 
+Timestamp
+---------
+
+When a record is created or replaced, the timestamp of the collection is incremented.
+
+It is possible to force the timestamp if the specified record has a
+``last_modified`` attribute.
+
+The specified value will be ignored if:
+
+* it is less than the current collection timestamp;
+* it is less or equal than the previously existing record timestamp (for replace).
+
+
 HTTP Status Code
 ----------------
 
@@ -665,6 +702,10 @@ HTTP Status Code
 
     A ``If-None-Match: *`` request header can be used to make sure the ``PUT``
     won't overwrite any record.
+
+.. versionadded:: 2.13::
+
+  Enforcement of the timestamp value for records has been added.
 
 
 PATCH /{collection}/<id>
@@ -758,6 +799,21 @@ If changing a record field violates a field unicity constraint, a
 ``409 Conflict`` error response is returned (see :ref:`error channel <error-responses>`).
 
 
+Timestamp
+---------
+
+When a record is modified, the timestamp of the collection is incremented.
+
+It is possible to force the timestamp if the specified record has a
+``last_modified`` attribute.
+
+
+The specified value will be ignored if:
+
+* it is less than the current collection timestamp;
+* it is less or equal than the previously existing record timestamp.
+
+
 HTTP Status Code
 ----------------
 
@@ -766,6 +822,10 @@ HTTP Status Code
   modified
 * ``409 Conflict``: If modifying this record violates a field unicity constraint
 * ``412 Precondition Failed``: Record changed since value in ``If-Match`` header
+
+.. versionadded:: 2.13::
+
+  Enforcement of the timestamp value for records has been added.
 
 
 .. _resource-permissions-attribute:

--- a/cliquet_docs/api/timestamps.rst
+++ b/cliquet_docs/api/timestamps.rst
@@ -68,3 +68,20 @@ The client can then choose to:
 
 * overwrite by repeating the request without ``If-Match``;
 * reconcile the resource by fetching, merging and repeating the request.
+
+
+Replication
+===========
+
+In order to replicate the timestamps when importing existing records,
+it is possible to force the last modified values.
+
+When a timestamp is specified, it should be strictly greater than the current
+collection timestamp.
+
+It will be ignored if:
+
+* it is less than the current collection timestamp;
+* it is less or equal than previously existing record timestamp (in case of replacement or modification).
+
+See :ref:`the resource endpoints documentation <resource-endpoints>`.

--- a/cliquet_docs/api/timestamps.rst
+++ b/cliquet_docs/api/timestamps.rst
@@ -76,12 +76,13 @@ Replication
 In order to replicate the timestamps when importing existing records,
 it is possible to force the last modified values.
 
-When a timestamp is specified, it should be strictly greater than the current
-collection timestamp.
+When a record is created (via POST or PUT), the specified timestamp becomes
+the new collection timestamp if it is in the future (i.e. greater than current
+one). If it is in the past, the record is created with the timestamp in the past
+but the collection timestamp is bumped into the future as usual.
 
-It will be ignored if:
-
-* it is less than the current collection timestamp;
-* it is less or equal than previously existing record timestamp (in case of replacement or modification).
+When a record is replaced, modified or deleted, if the specified timestamp is less
+or equal than the existing record, the value is simply ignored and the timestamp
+is bumped into the future as usual.
 
 See :ref:`the resource endpoints documentation <resource-endpoints>`.


### PR DESCRIPTION
I rewrote cleanly 4 four tests for storage backends:
- create with timestamp specified in future and past
- update with timestamp specified in future and past

I fixed the migrations of PR #604 

And I updated the migration of PR #649 to fix the behaviour of PG for collection timestamps when specified record timestamp were in the past.