### PR TITLE
data-->'field' break with numeric comparison.

### DIFF
--- a/cliquet/storage/postgresql/__init__.py
+++ b/cliquet/storage/postgresql/__init__.py
@@ -590,24 +590,9 @@ class Storage(StorageBase):
                 # JSON operator ->> retrieves values as text.
                 # If field is missing, we default to ''.
                 sql_field = "coalesce(data->>:%s, '')" % field_holder
-
-                # Handle the special cases of numeric values
-                # Digits starting with a 0 are probably strings.
-                # (e.g phone numbers) and Boolean are not digits
-                if not six.text_type(value).startswith('0') and \
+                if isinstance(value, (int, float)) and \
                    value not in (True, False):
-                    try:
-                        value = int(value)
-                        sql_field = "(data->>:%s)::numeric" % field_holder
-                    except ValueError:
-                        try:
-                            value = float(value)
-                            sql_field = "(data->>:%s)::numeric" % field_holder
-                        except ValueError:
-                            pass
-                    except TypeError:
-                        # For list and tuples
-                        pass
+                    sql_field = "(data->>:%s)::numeric" % field_holder
 
             if filtr.operator not in (COMPARISON.IN, COMPARISON.EXCLUDE):
                 # For the IN operator, let psycopg escape the values list.

--- a/cliquet/storage/postgresql/__init__.py
+++ b/cliquet/storage/postgresql/__init__.py
@@ -588,7 +588,7 @@ class Storage(StorageBase):
                 holders[field_holder] = filtr.field
                 # JSON operator ->> retrieves values as text.
                 # If field is missing, we default to ''.
-                sql_field = "coalesce(data->>:%s, '')" % field_holder
+                sql_field = "coalesce(data->:%s, '')" % field_holder
 
             if filtr.operator not in (COMPARISON.IN, COMPARISON.EXCLUDE):
                 # For the IN operator, let psycopg escape the values list.
@@ -663,7 +663,7 @@ class Storage(StorageBase):
             else:
                 field_holder = 'sort_field_%s' % i
                 holders[field_holder] = sort.field
-                sql_field = 'data->>(:%s)' % field_holder
+                sql_field = 'data->(:%s)' % field_holder
 
             sql_direction = 'ASC' if sort.direction > 0 else 'DESC'
             sql_sort = "%s %s" % (sql_field, sql_direction)

--- a/cliquet/storage/postgresql/__init__.py
+++ b/cliquet/storage/postgresql/__init__.py
@@ -578,6 +578,12 @@ class Storage(StorageBase):
         for i, filtr in enumerate(filters):
             value = filtr.value
 
+            try:
+                value = float(value)
+                is_numeric = True
+            except ValueError:
+                is_numeric = False
+
             if filtr.field == id_field:
                 sql_field = 'id'
             elif filtr.field == modified_field:
@@ -586,9 +592,12 @@ class Storage(StorageBase):
                 # Safely escape field name
                 field_holder = '%s_field_%s' % (prefix, i)
                 holders[field_holder] = filtr.field
-                # JSON operator ->> retrieves values as text.
                 # If field is missing, we default to ''.
-                sql_field = "coalesce(data->:%s, '')" % field_holder
+                if is_numeric:
+                    sql_field = "data->:%s" % field_holder
+                else:
+                    # JSON operator ->> retrieves values as text.
+                    sql_field = "coalesce(data->>:%s, '')" % field_holder
 
             if filtr.operator not in (COMPARISON.IN, COMPARISON.EXCLUDE):
                 # For the IN operator, let psycopg escape the values list.

--- a/cliquet/tests/test_storage.py
+++ b/cliquet/tests/test_storage.py
@@ -381,6 +381,17 @@ class BaseTestStorage(object):
         self.assertEqual(records[2]['code'], 10)
         self.assertEqual(len(records), 3)
 
+    def test_get_all_can_filter_with_strings(self):
+        for l in ["Rémy", "Alexis", "Marie"]:
+            self.create_record({'name': l})
+        sorting = [Sort('name', 1)]
+        filters = [Filter('name', "Mathieu", utils.COMPARISON.LT)]
+        records, _ = self.storage.get_all(sorting=sorting, filters=filters,
+                                          **self.storage_kw)
+        self.assertEqual(records[0]['name'], "Alexis")
+        self.assertEqual(records[1]['name'], "Marie")
+        self.assertEqual(len(records), 2)
+
     def test_get_all_can_filter_with_list_of_values_on_id(self):
         record1 = self.create_record({'code': 'a'})
         record2 = self.create_record({'code': 'b'})

--- a/cliquet/tests/test_storage.py
+++ b/cliquet/tests/test_storage.py
@@ -369,6 +369,17 @@ class BaseTestStorage(object):
                                           **self.storage_kw)
         self.assertEqual(len(records), 2)
 
+    def test_get_all_can_filter_with_list_of_numeric_values(self):
+        for l in [1, 10, 6, 46]:
+            self.create_record({'code': l})
+        sorting = [Sort('code', 1)]
+        filters = [Filter('code', 10, utils.COMPARISON.MAX)]
+        records, _ = self.storage.get_all(sorting=sorting, filters=filters,
+                                          **self.storage_kw)
+        self.assertEqual(records[0]['code'], 1)
+        self.assertEqual(records[1]['code'], 6)
+        self.assertEqual(records[2]['code'], 10)
+
     def test_get_all_can_filter_with_list_of_values_on_id(self):
         record1 = self.create_record({'code': 'a'})
         record2 = self.create_record({'code': 'b'})
@@ -893,6 +904,20 @@ class DeletedRecordsTest(object):
         self.assertIn('deleted', records[0])
         self.assertIn('deleted', records[1])
         self.assertNotIn('deleted', records[2])
+
+    def test_sorting_on_numeric_arbitrary_field(self):
+        filters = self._get_last_modified_filters()
+        for l in [1, 10, 6, 46]:
+            self.create_record({'status': l})
+
+        sorting = [Sort('status', -1)]
+        records, _ = self.storage.get_all(sorting=sorting, filters=filters,
+                                          include_deleted=True,
+                                          **self.storage_kw)
+        self.assertEqual(records[0]['status'], 46)
+        self.assertEqual(records[1]['status'], 10)
+        self.assertEqual(records[2]['status'], 6)
+        self.assertEqual(records[3]['status'], 1)
 
     #
     # Filtering

--- a/cliquet/tests/test_storage.py
+++ b/cliquet/tests/test_storage.py
@@ -369,16 +369,32 @@ class BaseTestStorage(object):
                                           **self.storage_kw)
         self.assertEqual(len(records), 2)
 
-    def test_get_all_can_filter_with_list_of_numeric_values(self):
+    def test_get_all_can_filter_with_numeric_values(self):
         for l in [1, 10, 6, 46]:
             self.create_record({'code': l})
         sorting = [Sort('code', 1)]
-        filters = [Filter('code', 10, utils.COMPARISON.MAX)]
+        filters = [Filter('code', "10", utils.COMPARISON.MAX)]
         records, _ = self.storage.get_all(sorting=sorting, filters=filters,
                                           **self.storage_kw)
         self.assertEqual(records[0]['code'], 1)
         self.assertEqual(records[1]['code'], 6)
         self.assertEqual(records[2]['code'], 10)
+        self.assertEqual(len(records), 3)
+
+    def test_get_all_can_filter_with_numeric_strings(self):
+        for l in ["0566199093", "0781566199"]:
+            self.create_record({'phone': l})
+        filters = [Filter('phone', "0566199093", utils.COMPARISON.EQ)]
+        records, _ = self.storage.get_all(filters=filters,
+                                          **self.storage_kw)
+        self.assertEqual(len(records), 1)
+
+    def test_get_all_can_filter_with_float_values(self):
+        for l in [10, 11.5, 8.5, 6, 7.5]:
+            self.create_record({'note': l})
+        filters = [Filter('note', "9.5", utils.COMPARISON.LT)]
+        records, _ = self.storage.get_all(filters=filters,
+                                          **self.storage_kw)
         self.assertEqual(len(records), 3)
 
     def test_get_all_can_filter_with_strings(self):

--- a/cliquet/tests/test_storage.py
+++ b/cliquet/tests/test_storage.py
@@ -379,6 +379,7 @@ class BaseTestStorage(object):
         self.assertEqual(records[0]['code'], 1)
         self.assertEqual(records[1]['code'], 6)
         self.assertEqual(records[2]['code'], 10)
+        self.assertEqual(len(records), 3)
 
     def test_get_all_can_filter_with_list_of_values_on_id(self):
         record1 = self.create_record({'code': 'a'})

--- a/cliquet/tests/test_storage.py
+++ b/cliquet/tests/test_storage.py
@@ -373,7 +373,7 @@ class BaseTestStorage(object):
         for l in [1, 10, 6, 46]:
             self.create_record({'code': l})
         sorting = [Sort('code', 1)]
-        filters = [Filter('code', "10", utils.COMPARISON.MAX)]
+        filters = [Filter('code', 10, utils.COMPARISON.MAX)]
         records, _ = self.storage.get_all(sorting=sorting, filters=filters,
                                           **self.storage_kw)
         self.assertEqual(records[0]['code'], 1)
@@ -392,7 +392,7 @@ class BaseTestStorage(object):
     def test_get_all_can_filter_with_float_values(self):
         for l in [10, 11.5, 8.5, 6, 7.5]:
             self.create_record({'note': l})
-        filters = [Filter('note', "9.5", utils.COMPARISON.LT)]
+        filters = [Filter('note', 9.5, utils.COMPARISON.LT)]
         records, _ = self.storage.get_all(filters=filters,
                                           **self.storage_kw)
         self.assertEqual(len(records), 3)


### PR DESCRIPTION
Refs Kinto/kinto#534

This is a really important bug which means sorting and filtering doesn't work with numeric values and the postgresql backend.

We probably have to write new tests to cover this.