### PR TITLE
Fix safe creation a record used to exist with same id (Kinto/kinto#512)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,10 @@ This document describes changes between each past release.
 3.2.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+**Bug fixes**
+
+- Fix safe creation (``If-None-Match: *``) if a record used to exist with the
+  same id (Kinto/kinto#512)
 
 
 3.1.1 (2016-04-05)

--- a/cliquet/resource/__init__.py
+++ b/cliquet/resource/__init__.py
@@ -756,6 +756,9 @@ class UserResource(object):
         if_match = decode_header(if_match) if if_match else None
 
         if record and if_none_match and decode_header(if_none_match) == '*':
+            if record.get(self.model.deleted_field, False):
+                # Tombstones should not prevent creation.
+                return
             modified_since = -1  # Always raise.
         elif if_match:
             try:

--- a/cliquet/tests/resource/test_preconditions.py
+++ b/cliquet/tests/resource/test_preconditions.py
@@ -174,6 +174,14 @@ class ModifiedMeanwhileTest(BaseTest):
         self.resource.record_id = self.resource.model.id_generator()
         self.resource.put()  # not raising.
 
+    def test_put_if_none_match_star_succeeds_if_tombstone_exists(self):
+        self.model.delete_record(self.stored)
+        self.resource.request.headers.pop('If-Match')
+        self.resource.request.headers['If-None-Match'] = '*'
+        self.resource.request.validated = {'data': {'field': 'new'}}
+        self.resource.record_id = self.stored['id']
+        self.resource.put()  # not raising.
+
     def test_post_if_none_match_star_fails_if_record_exists(self):
         self.resource.request.headers.pop('If-Match')
         self.resource.request.headers['If-None-Match'] = '*'


### PR DESCRIPTION
Fixes tests of Kinto/kinto#512

@Natim r?