### PR TITLE
Fix changelog about cache_prefix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,10 @@ This document describes changes between each past release.
 - Fix safe creation (``If-None-Match: *``) if a record used to exist with the
   same id (Kinto/kinto#512)
 
+**New features**
+
+- A ``cache_prefix`` setting was added for cache backends. (#680)
+
 
 3.1.1 (2016-04-05)
 ------------------
@@ -31,7 +35,6 @@ This document describes changes between each past release.
 **New features**
 
 - Default console log renderer now has colours (#671)
-- A ``cache_prefix`` setting was added for cache backends. (#680)
 
 **Bug fixes**
 


### PR DESCRIPTION
The changelog entry was misplaced because the PR #680 was not rebased before merging ;)

As a consequence the cliquet release 3.1.1 should have been tagged 3.2.0 instead :) 

r? @magopian 

![capture d ecran de 2016-04-12 16-21-29](https://cloud.githubusercontent.com/assets/546692/14463298/c2fba73c-00ca-11e6-8136-420d3b7da69e.png)