### PR TITLE
Fix migration of triggers in PostgreSQL storage backend …

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,10 @@ This document describes changes between each past release.
 3.2.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+**Bug fixes**
+
+- Fix migration of triggers in PostgreSQL storage backend when upgrading from <3.0.0.
+  Running the ``migrate`` command will basically re-create them (fixes Kinto/kinto#559)
 
 
 3.1.2 (2016-04-19)

--- a/cliquet/storage/postgresql/__init__.py
+++ b/cliquet/storage/postgresql/__init__.py
@@ -66,7 +66,7 @@ class Storage(StorageBase):
 
     """  # NOQA
 
-    schema_version = 10
+    schema_version = 11
 
     def __init__(self, client, max_fetch_size, *args, **kwargs):
         super(Storage, self).__init__(*args, **kwargs)

--- a/cliquet/storage/postgresql/migrations/migration_009_010.sql
+++ b/cliquet/storage/postgresql/migrations/migration_009_010.sql
@@ -28,6 +28,8 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+DROP TRIGGER IF EXISTS tgr_records_last_modified ON records;
+DROP TRIGGER IF EXISTS tgr_deleted_last_modified ON deleted;
 
 CREATE OR REPLACE FUNCTION bump_timestamp()
 RETURNS trigger AS $$
@@ -82,6 +84,14 @@ BEGIN
     RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
+
+CREATE TRIGGER tgr_records_last_modified
+BEFORE INSERT OR UPDATE ON records
+FOR EACH ROW EXECUTE PROCEDURE bump_timestamp();
+
+CREATE TRIGGER tgr_deleted_last_modified
+BEFORE INSERT OR UPDATE ON deleted
+FOR EACH ROW EXECUTE PROCEDURE bump_timestamp();
 
 
 -- Bump storage schema version.

--- a/cliquet/storage/postgresql/migrations/migration_010_011.sql
+++ b/cliquet/storage/postgresql/migrations/migration_010_011.sql
@@ -1,0 +1,14 @@
+DROP TRIGGER IF EXISTS tgr_records_last_modified ON records;
+DROP TRIGGER IF EXISTS tgr_deleted_last_modified ON deleted;
+
+CREATE TRIGGER tgr_records_last_modified
+BEFORE INSERT OR UPDATE ON records
+FOR EACH ROW EXECUTE PROCEDURE bump_timestamp();
+
+CREATE TRIGGER tgr_deleted_last_modified
+BEFORE INSERT OR UPDATE ON deleted
+FOR EACH ROW EXECUTE PROCEDURE bump_timestamp();
+
+
+-- Bump storage schema version.
+INSERT INTO metadata (name, value) VALUES ('storage_schema_version', '11');

--- a/cliquet/storage/postgresql/schema.sql
+++ b/cliquet/storage/postgresql/schema.sql
@@ -241,4 +241,4 @@ INSERT INTO metadata (name, value) VALUES ('created_at', NOW()::TEXT);
 
 -- Set storage schema version.
 -- Should match ``cliquet.storage.postgresql.PostgreSQL.schema_version``
-INSERT INTO metadata (name, value) VALUES ('storage_schema_version', '10');
+INSERT INTO metadata (name, value) VALUES ('storage_schema_version', '11');

--- a/cliquet/tests/test_storage_migrations.py
+++ b/cliquet/tests/test_storage_migrations.py
@@ -133,8 +133,15 @@ class PostgresqlStorageMigrationTest(unittest.TestCase):
         version = self.storage._get_installed_version()
         self.assertEqual(version, self.version)
 
+        # Check that previously created record is still here
         migrated, count = self.storage.get_all('test', 'jean-louis')
         self.assertEqual(migrated[0], before)
+
+        # Check that new records can be created
+        r = self.storage.create('test', ',jean-louis', {'drink': 'mate'})
+
+        # And deleted
+        self.storage.delete('test', ',jean-louis', r['id'])
 
     def test_every_available_migration_succeeds_if_tables_were_flushed(self):
         # During tests, tables can be flushed.


### PR DESCRIPTION
Migrations from cliquet<3.0.0 were broken.

Tests were testing that migrations did not loose any records. They now test create + delete.

Fixes Kinto/kinto#559

@Natim r?