### PR TITLE
Fix crash when providing duplicated principals in permissions with PostgreSQL permission backend (fixes #702)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ This document describes changes between each past release.
 
 - Redirects version prefix to hello page when trailing_slash_redirect is enabled. (#700)
 - Fix crash when setting empty permission list with PostgreSQL permission backend (fixes Kinto/kinto#575)
+- Fix crash when providing duplicated principals in permissions with PostgreSQL permission backend (fixes #702)
 
 
 3.1.3 (2016-04-29)

--- a/cliquet/permission/postgresql/__init__.py
+++ b/cliquet/permission/postgresql/__init__.py
@@ -295,7 +295,7 @@ class Permission(PermissionBase):
         for i, (perm, principals) in enumerate(permissions.items()):
             placeholders['perm_%s' % i] = perm
             specified_perms.append("(:perm_%s)" % i)
-            for principal in principals:
+            for principal in set(principals):
                 j = len(new_perms)
                 placeholders['principal_%s' % j] = principal
                 new_perms.append("(:perm_%s, :principal_%s)" % (i, j))

--- a/cliquet/tests/test_permission.py
+++ b/cliquet/tests/test_permission.py
@@ -414,6 +414,16 @@ class BaseTestPermission(object):
             "write": {"user1"}
         })
 
+    def test_replace_object_permission_supports_duplicated_entries(self):
+        self.permission.add_principal_to_ace('/url/a/id/1', 'write', 'user1')
+        self.permission.replace_object_permissions('/url/a/id/1', {
+            "write": ["user1", "user1"]
+        })
+        object_permissions = self.permission.object_permissions('/url/a/id/1')
+        self.assertDictEqual(object_permissions, {
+            "write": {"user1"}
+        })
+
     def test_replace_object_permission_supports_empty_list(self):
         self.permission.add_principal_to_ace('/url/a/id/1', 'write', 'user1')
         self.permission.replace_object_permissions('/url/a/id/1', {


### PR DESCRIPTION
@Natim @glasserc r?