### PR TITLE
Indicate that Cliquet is now deprecated

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,15 @@
+Deprecation Notice
+==================
+
+Cliquet has been folded into the `Kinto
+<https://github.com/Kinto/kinto/>`_ package under the new name
+``kinto.core``. You should update your code to import ``kinto.core``
+instead of ``cliquet``, and all ``cliquet.*`` settings are now
+prefixed with ``kinto`` instead. See
+https://mail.mozilla.org/pipermail/kinto/2016-May/000119.html for more
+about the background for this decision.
+
+
 Cliquet
 =======
 

--- a/cliquet/__init__.py
+++ b/cliquet/__init__.py
@@ -17,7 +17,7 @@ from cliquet.logs import logger
 
 
 import warnings
-warnings.warn("cliquet is now deprecated. Please update to kinto.core at "
+warnings.warn("Cliquet is now deprecated. Please update to kinto.core at "
               "https://github.com/Kinto/kinto. See "
               "https://github.com/mozilla-services/cliquet/issues/687 "
               "for more information.", DeprecationWarning)

--- a/cliquet/__init__.py
+++ b/cliquet/__init__.py
@@ -17,11 +17,16 @@ from cliquet.logs import logger
 
 
 import warnings
-warnings.warn("Cliquet is now deprecated. Please update to kinto.core at "
-              "https://github.com/Kinto/kinto. See "
-              "https://github.com/mozilla-services/cliquet/issues/687 "
-              "for more information.", DeprecationWarning)
 
+DEPRECATION_MESSAGE = ''.join([
+    "Cliquet is now deprecated. Please update to kinto.core at ",
+    "https://github.com/Kinto/kinto. See ",
+    "https://github.com/mozilla-services/cliquet/issues/687 ",
+    "for more information.",
+    ])
+
+warnings.warn(DEPRECATION_MESSAGE, DeprecationWarning)
+logger.warn(DEPRECATION_MESSAGE)
 
 # Module version, as defined in PEP-0396.
 __version__ = pkg_resources.get_distribution(__package__).version

--- a/cliquet/__init__.py
+++ b/cliquet/__init__.py
@@ -26,7 +26,7 @@ DEPRECATION_MESSAGE = ''.join([
     ])
 
 warnings.warn(DEPRECATION_MESSAGE, DeprecationWarning)
-logger.warn(DEPRECATION_MESSAGE)
+
 
 # Module version, as defined in PEP-0396.
 __version__ = pkg_resources.get_distribution(__package__).version
@@ -126,6 +126,7 @@ class Service(CorniceService):
 
 
 def includeme(config):
+
     settings = config.get_settings()
 
     # Heartbeat registry.
@@ -166,6 +167,8 @@ def includeme(config):
     for step in aslist(settings['initialization_sequence']):
         step_func = config.maybe_dotted(step)
         step_func(config)
+
+    logger.warn(DEPRECATION_MESSAGE)
 
     # Custom helpers.
     config.add_request_method(follow_subrequest)

--- a/cliquet/__init__.py
+++ b/cliquet/__init__.py
@@ -16,6 +16,13 @@ from cliquet.utils import (
 from cliquet.logs import logger
 
 
+import warnings
+warnings.warn("cliquet is now deprecated. Please update to kinto.core at "
+              "https://github.com/Kinto/kinto. See "
+              "https://github.com/mozilla-services/cliquet/issues/687 "
+              "for more information.", DeprecationWarning)
+
+
 # Module version, as defined in PEP-0396.
 __version__ = pkg_resources.get_distribution(__package__).version
 


### PR DESCRIPTION
Following what I saw at https://github.com/citusdata/pg_shard, I added a deprecation notice to the README. Also, following http://stackoverflow.com/questions/24085400/how-to-formally-deprecate-a-pip-package, add a warning when the package is imported.

We can merge this once the tests pass on my fork of Kinto and I merge that into master.